### PR TITLE
Potential fix for code scanning alert no. 9: Uncontrolled data used in path expression

### DIFF
--- a/src/routes/static.py
+++ b/src/routes/static.py
@@ -13,8 +13,9 @@ def serve(path):
         return send_from_directory(static_folder_path, 'about.html')
     
     # Prevent path traversal attacks by ensuring the resolved path is within the static folder
-    requested_path = os.path.abspath(os.path.join(static_folder_path, path))
-    if not requested_path.startswith(os.path.abspath(static_folder_path)):
+    requested_path = os.path.realpath(os.path.join(static_folder_path, path))
+    static_folder_realpath = os.path.realpath(static_folder_path)
+    if not requested_path.startswith(static_folder_realpath + os.sep):
         abort(403)  # Forbidden - attempt to access outside of static folder
     
     # Check if the file exists


### PR DESCRIPTION
Potential fix for [https://github.com/TonyXTYan/CHSH-Game/security/code-scanning/9](https://github.com/TonyXTYan/CHSH-Game/security/code-scanning/9)

To fix the issue, we will:
1. Normalize the `requested_path` using `os.path.realpath` instead of `os.path.abspath`. This ensures that symbolic links are resolved, preventing attackers from exploiting them to escape the `static_folder_path`.
2. Verify that the normalized `requested_path` starts with the normalized `static_folder_path` to ensure it is contained within the intended directory.
3. Use `send_from_directory` to securely serve files, as it is designed to handle paths safely.

The changes will be made in the `serve` function in `src/routes/static.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
