### PR TITLE
Potential fix for code scanning alert no. 9: Uncontrolled data used in path expression

### DIFF
--- a/src/routes/static.py
+++ b/src/routes/static.py
@@ -12,16 +12,27 @@ def serve(path):
     if path == "about": # Specific route for about.html
         return send_from_directory(static_folder_path, 'about.html')
     
-    # Prevent path traversal attacks by ensuring the resolved path is within the static folder
-    requested_path = os.path.realpath(os.path.join(static_folder_path, path))
+    # Normalize the path to prevent path traversal attacks
+    normalized_path = os.path.normpath(path)
+    
+    # Ensure the normalized path does not contain any ".." segments
+    if ".." in normalized_path.split(os.sep):
+        abort(403)  # Forbidden - attempt to traverse directories
+    
+    # Sanitize the file name to remove special characters
+    from werkzeug.utils import secure_filename
+    safe_path = secure_filename(normalized_path)
+    
+    # Resolve the full requested path
+    requested_path = os.path.realpath(os.path.join(static_folder_path, safe_path))
     static_folder_realpath = os.path.realpath(static_folder_path)
     if not requested_path.startswith(static_folder_realpath + os.sep):
         abort(403)  # Forbidden - attempt to access outside of static folder
     
     # Check if the file exists
-    if path != "" and os.path.exists(requested_path) and os.path.isfile(requested_path):
+    if safe_path != "" and os.path.exists(requested_path) and os.path.isfile(requested_path):
         # Use safe send_from_directory which handles paths securely
-        return send_from_directory(static_folder_path, path)
+        return send_from_directory(static_folder_path, safe_path)
     else:
         index_path = os.path.join(static_folder_path, 'index.html')
         if os.path.exists(index_path):


### PR DESCRIPTION
Potential fix for [https://github.com/TonyXTYan/CHSH-Game/security/code-scanning/9](https://github.com/TonyXTYan/CHSH-Game/security/code-scanning/9)

To fix the issue, we will validate the `path` input more rigorously before using it in file operations. Specifically:
1. Normalize the `path` input using `os.path.normpath` to remove any `..` segments or redundant separators.
2. Ensure that the normalized `path` does not contain any `..` segments after normalization, as this could indicate an attempt to escape the intended directory.
3. Use `werkzeug.utils.secure_filename` to sanitize the file name and remove any special characters that could lead to unsafe behavior.
4. Retain the existing check to ensure that the resolved `requested_path` is within the static folder.

These changes will ensure that the `path` input is safe and does not allow access to unintended files.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
