### PR TITLE
Disable team stats streaming by default

### DIFF
--- a/src/sockets/team_management.py
+++ b/src/sockets/team_management.py
@@ -5,10 +5,14 @@ from sqlalchemy import func
 from src.config import app, socketio, db
 from src.state import state
 from src.models.quiz_models import Teams, PairQuestionRounds, Answers
-from src.sockets.dashboard import emit_dashboard_team_update, emit_dashboard_full_update, clear_team_caches
 from src.game_logic import start_new_round_for_pair
 import logging
 from typing import Dict, Any, List, Optional
+
+# Use delayed imports to avoid circular import issues
+def get_dashboard_functions():
+    from src.sockets.dashboard import emit_dashboard_team_update, emit_dashboard_full_update, clear_team_caches
+    return emit_dashboard_team_update, emit_dashboard_full_update, clear_team_caches
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -60,6 +64,7 @@ def handle_connect() -> None:
         # By default, treat all non-dashboard connections as players
         if sid not in state.dashboard_clients:
             state.connected_players.add(sid)
+            _, emit_dashboard_full_update, _ = get_dashboard_functions()
             emit_dashboard_full_update()  # Use full update to refresh player count
         
         emit('connection_established', {
@@ -81,6 +86,7 @@ def handle_disconnect() -> None:
         # Remove from connected players list regardless of team status
         if sid in state.connected_players:
             state.connected_players.remove(sid)
+            _, emit_dashboard_full_update, _ = get_dashboard_functions()
             emit_dashboard_full_update()  # Update dashboard with new player count
 
         # Handle team-related disconnection
@@ -132,6 +138,7 @@ def handle_disconnect() -> None:
                         
                         db.session.commit()
                         # Clear caches after team state change
+                        emit_dashboard_team_update, _, clear_team_caches = get_dashboard_functions()
                         clear_team_caches()
                         
                         try:
@@ -170,6 +177,7 @@ def on_create_team(data: Dict[str, Any]) -> None:
         db.session.add(new_team_db)
         db.session.commit()
         # Clear caches after team state change
+        _, _, clear_team_caches = get_dashboard_functions()
         clear_team_caches()
         state.active_teams[team_name] = {
             'players': [sid],
@@ -200,6 +208,7 @@ def on_create_team(data: Dict[str, Any]) -> None:
             'game_started': state.game_started
         })  # type: ignore
         
+        emit_dashboard_team_update, _, _ = get_dashboard_functions()
         emit_dashboard_team_update()
     except Exception as e:
         logger.error(f"Error in on_create_team: {str(e)}", exc_info=True)
@@ -235,6 +244,7 @@ def on_join_team(data: Dict[str, Any]) -> None:
             db_team.is_active = True
             db.session.commit()
             # Clear caches after team state change
+            _, _, clear_team_caches = get_dashboard_functions()
             clear_team_caches()
 
         team_is_now_full = len(team_info['players']) == 2
@@ -270,6 +280,7 @@ def on_join_team(data: Dict[str, Any]) -> None:
         
         # Update dashboard
         # Force refresh when team becomes active (critical state change)
+        emit_dashboard_team_update, _, _ = get_dashboard_functions()
         emit_dashboard_team_update(force_refresh=team_is_now_full)
         
         # If the game has already started and the team is now full, start a new round for them
@@ -311,6 +322,7 @@ def on_reactivate_team(data: Dict[str, Any]) -> None:
             team.player1_session_id = sid
             db.session.commit()
             # Clear caches after team state change
+            _, _, clear_team_caches = get_dashboard_functions()
             clear_team_caches()
 
             # Query for the highest round number previously played by this team
@@ -344,6 +356,7 @@ def on_reactivate_team(data: Dict[str, Any]) -> None:
                 'game_started': state.game_started
             })  # type: ignore
             
+            emit_dashboard_team_update, _, _ = get_dashboard_functions()
             emit_dashboard_team_update()
             
     except Exception as e:
@@ -407,6 +420,7 @@ def on_leave_team(data: Dict[str, Any]) -> None:
             if db_team: # Commit changes if db_team was involved
                 db.session.commit()
                 # Clear caches after team state change
+                _, _, clear_team_caches = get_dashboard_functions()
                 clear_team_caches()
 
             emit('left_team_success', {'message': 'You have left the team.'}, to=sid)  # type: ignore
@@ -423,6 +437,7 @@ def on_leave_team(data: Dict[str, Any]) -> None:
                 'game_started': state.game_started
             })  # type: ignore
             # Force refresh for critical team state changes like leaving
+            emit_dashboard_team_update, _, _ = get_dashboard_functions()
             emit_dashboard_team_update(force_refresh=True)
     except Exception as e:
         logger.error(f"Error in on_leave_team: {str(e)}", exc_info=True)

--- a/src/static/dashboard.css
+++ b/src/static/dashboard.css
@@ -530,3 +530,22 @@ footer {
         transform: rotate(-360deg);
     }
 }
+
+/* Multiple dashboard notice styles */
+.multiple-dashboard-notice {
+    background-color: #fff3cd;
+    border: 1px solid #ffeaa7;
+    border-radius: 4px;
+    padding: 12px;
+    margin-bottom: 15px;
+    color: #856404;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.multiple-dashboard-notice::before {
+    content: "⚠️";
+    font-size: 16px;
+}

--- a/src/static/dashboard.js
+++ b/src/static/dashboard.js
@@ -403,6 +403,13 @@ socket.on("dashboard_update", (data) => {
     if (data.game_state && data.game_state.streaming_enabled !== undefined) {
         answerStreamEnabled = data.game_state.streaming_enabled;
         updateStreamingUI();
+        
+        // Update UI based on multiple dashboard status
+        if (data.game_state.multiple_dashboards && data.game_state.streaming_disabled_reason === 'multiple_dashboards') {
+            showMultipleDashboardNotice();
+        } else {
+            hideMultipleDashboardNotice();
+        }
     }
 
     // Refresh team details popup if open
@@ -762,8 +769,33 @@ function updateStreamingUI() {
 }
 
 function toggleAnswerStream() {
-    answerStreamEnabled = !answerStreamEnabled;
-    updateStreamingUI();
+    // Send toggle request to server instead of changing local state directly
+    socket.emit('toggle_streaming');
+}
+
+function showMultipleDashboardNotice() {
+    // Show a notice that streaming is disabled due to multiple dashboards
+    let notice = document.getElementById('multiple-dashboard-notice');
+    if (!notice) {
+        notice = document.createElement('div');
+        notice.id = 'multiple-dashboard-notice';
+        notice.className = 'multiple-dashboard-notice';
+        notice.innerHTML = 'Answer streaming is disabled due to multiple dashboard connections. Click streaming button to override.';
+        
+        // Insert the notice near the streaming toggle
+        const streamingHeader = document.getElementById('live-answer-log-header');
+        if (streamingHeader) {
+            streamingHeader.parentNode.insertBefore(notice, streamingHeader);
+        }
+    }
+    notice.style.display = 'block';
+}
+
+function hideMultipleDashboardNotice() {
+    const notice = document.getElementById('multiple-dashboard-notice');
+    if (notice) {
+        notice.style.display = 'none';
+    }
 }
 
 function togglePause() {


### PR DESCRIPTION
Teams stats streaming is now disabled by default for multiple dashboard clients to improve performance.

Key changes include:
*   In `src/sockets/dashboard.py`:
    *   A `dashboard_client_streaming` dictionary tracks per-client streaming preferences.
    *   `on_dashboard_join` initializes client preferences, auto-disabling streaming if multiple dashboards are detected.
    *   A new `on_toggle_streaming` event allows clients to request streaming state changes, which are then aggregated.
    *   `emit_dashboard_full_update` now sends `streaming_disabled_reason` and `multiple_dashboards` flags.
    *   Helper functions `should_auto_disable_streaming`, `get_effective_streaming_state`, and `update_global_streaming_state` manage the global streaming state.
*   In `src/static/dashboard.js`:
    *   The `dashboard_update` handler displays a notice (`showMultipleDashboardNotice`) when streaming is auto-disabled.
    *   `toggleAnswerStream` now sends a `toggle_streaming` event to the server.
*   `src/static/dashboard.css` was updated with styles for the new notice.
*   Circular import issues in `src/sockets/game.py` and `src/sockets/team_management.py` were resolved by using delayed imports for dashboard functions.
*   New unit tests were added to verify the multi-dashboard streaming logic and the `toggle_streaming` event.