### PR TITLE
Check and reactivate inactive team names

### DIFF
--- a/TEAM_NAME_CONFLICT_RESOLUTION_TESTING.md
+++ b/TEAM_NAME_CONFLICT_RESOLUTION_TESTING.md
@@ -132,6 +132,7 @@ The team name conflict resolution feature includes:
 ### Test Types
 - **Unit Tests**: 7 new tests covering individual functions and error paths
 - **Integration Tests**: 4 new tests covering complete user workflows
+- **Updated Existing Tests**: 1 existing test updated to support new `is_reactivated` flag
 - **Mock Coverage**: Database operations, socket events, state management
 - **Real Database Tests**: Using fixtures for authentic database interactions
 
@@ -176,4 +177,25 @@ python -m pytest tests/unit/test_team_management.py tests/integration/test_playe
 - **Browser Testing**: Client-side handling of `is_reactivated` flag
 - **Dashboard Testing**: Real-time updates when teams are automatically reactivated
 
-This testing suite ensures the team name conflict resolution feature is robust, reliable, and maintains the expected user experience while preventing the original duplicate team name bug.
+## Issue Fixed
+
+During testing, we identified and fixed an issue with the existing `test_reactivate_team_success` test. The test was expecting the old response format that didn't include the `is_reactivated` flag. The test has been updated to expect the new format:
+
+```python
+# Updated test now expects:
+{
+    'team_name': 'test_team',
+    'team_id': inactive_team.team_id,
+    'message': 'Team reactivated successfully. Waiting for another player.',
+    'game_started': state.game_started,
+    'game_mode': state.game_mode,
+    'player_slot': 1,
+    'is_reactivated': True  # This flag was added by the new implementation
+}
+```
+
+This ensures consistency between explicit team reactivation (`reactivate_team`) and automatic reactivation through team creation (`create_team`).
+
+## Summary
+
+This testing suite ensures the team name conflict resolution feature is robust, reliable, and maintains the expected user experience while preventing the original duplicate team name bug. All tests now pass successfully with the updated implementation.

--- a/TEAM_NAME_CONFLICT_RESOLUTION_TESTING.md
+++ b/TEAM_NAME_CONFLICT_RESOLUTION_TESTING.md
@@ -1,0 +1,179 @@
+# Team Name Conflict Resolution - Testing Coverage
+
+## Overview
+
+This document details the comprehensive testing coverage added for the team name conflict resolution implementation in the CHSH Game application. The feature automatically reactivates inactive teams when users attempt to create teams with names that match existing inactive teams.
+
+## Implementation Summary
+
+The team name conflict resolution feature includes:
+
+- **`_reactivate_team_internal()` helper function**: Handles the core reactivation logic
+- **Modified `on_create_team()` function**: Checks for inactive teams and automatically reactivates them
+- **Enhanced user experience**: Seamless reactivation without requiring users to know about inactive teams
+- **History preservation**: Reactivated teams retain their original team ID and round history
+- **Proper state management**: Updates both database and in-memory state correctly
+
+## Unit Tests Added
+
+### Core Functionality Tests
+
+#### `test_create_team_reactivates_inactive_team`
+- **Purpose**: Tests automatic reactivation when creating a team with an inactive team's name
+- **Verifies**: 
+  - Database team is marked as active
+  - Player is assigned to `player1_session_id`
+  - State is properly updated with team info
+  - `is_reactivated: True` flag is included in response
+  - Dashboard updates are triggered
+  - Socket room management works correctly
+
+#### `test_create_team_reactivation_failure_fallback`
+- **Purpose**: Tests error handling when reactivation fails
+- **Verifies**:
+  - `_reactivate_team_internal()` is called with correct parameters
+  - Error message is emitted when reactivation fails
+  - System gracefully handles reactivation failures
+
+### Helper Function Tests
+
+#### `test_reactivate_team_internal_success`
+- **Purpose**: Tests the core `_reactivate_team_internal()` helper function
+- **Verifies**:
+  - Returns `True` for successful reactivation
+  - Database team is activated and player assigned
+  - All state dictionaries are properly updated
+  - Cache clearing and room joining occur
+  - Team ID mapping is restored
+
+#### `test_reactivate_team_internal_team_not_found`
+- **Purpose**: Tests behavior when trying to reactivate non-existent team
+- **Verifies**: Returns `False` when team doesn't exist
+
+#### `test_reactivate_team_internal_name_conflict`
+- **Purpose**: Tests prevention of reactivation when active team exists with same name
+- **Verifies**: Returns `False` when name conflict exists with active team
+
+#### `test_reactivate_team_internal_preserves_round_history`
+- **Purpose**: Tests that team history is preserved during reactivation
+- **Verifies**:
+  - Previous round history is maintained
+  - `current_round_number` reflects last played round
+  - Database round records are preserved
+
+#### `test_reactivate_team_internal_exception_handling`
+- **Purpose**: Tests graceful error handling in the helper function
+- **Verifies**: Returns `False` when database exceptions occur
+
+## Integration Tests Added
+
+### End-to-End Workflow Tests
+
+#### `test_create_team_automatically_reactivates_inactive`
+- **Purpose**: Tests complete user workflow of automatic reactivation
+- **Workflow**:
+  1. Create team and join with two players
+  2. Both players leave (team becomes inactive)
+  3. New player creates team with same name
+  4. Verify automatic reactivation occurs
+- **Verifies**:
+  - Same team ID is reused
+  - `is_reactivated: True` flag in response
+  - Team is active in database
+  - Correct success message
+
+#### `test_create_team_reactivation_preserves_team_id`
+- **Purpose**: Tests that team ID and history are preserved across reactivation
+- **Workflow**:
+  1. Create team with game history (multiple rounds)
+  2. Players leave (team becomes inactive)
+  3. New player reactivates through create_team
+  4. Verify history preservation
+- **Verifies**:
+  - Original team ID is maintained
+  - Round history count is preserved in state
+  - Database round records remain intact
+
+#### `test_create_team_vs_explicit_reactivate_identical_behavior`
+- **Purpose**: Tests that automatic and explicit reactivation produce identical results
+- **Workflow**:
+  1. Create and deactivate two separate teams
+  2. Reactivate one through `create_team`, other through `reactivate_team`
+  3. Compare responses and behavior
+- **Verifies**:
+  - Both methods return identical response structure
+  - Both include `is_reactivated: True` flag
+  - Both preserve team history correctly
+  - Consistent player slot assignment
+
+#### `test_create_team_name_conflict_with_active_team`
+- **Purpose**: Tests that active team names cannot be used for new teams
+- **Workflow**:
+  1. Create active team
+  2. Try to create another team with same name
+  3. Verify error handling
+- **Verifies**:
+  - Error is returned instead of reactivation
+  - Error message indicates name already exists
+  - No unintended reactivation occurs
+
+## Test Coverage Metrics
+
+### Areas Covered
+- ✅ **Automatic reactivation logic**: Core functionality fully tested
+- ✅ **Error handling**: Database errors, missing teams, name conflicts
+- ✅ **State management**: All state dictionaries properly updated
+- ✅ **History preservation**: Round count and team ID maintained
+- ✅ **User experience**: Seamless workflow without user awareness needed
+- ✅ **Socket management**: Room joining and event emissions
+- ✅ **Dashboard integration**: Cache clearing and updates
+- ✅ **Edge cases**: Failed reactivation, exception handling
+
+### Test Types
+- **Unit Tests**: 7 new tests covering individual functions and error paths
+- **Integration Tests**: 4 new tests covering complete user workflows
+- **Mock Coverage**: Database operations, socket events, state management
+- **Real Database Tests**: Using fixtures for authentic database interactions
+
+## Running the Tests
+
+### Unit Tests Only
+```bash
+# Run all new team conflict resolution unit tests
+python -m pytest tests/unit/test_team_management.py -k "reactivate_team_internal or create_team_reactivates_inactive_team or create_team_reactivation_failure" -v
+
+# Run specific test
+python -m pytest tests/unit/test_team_management.py::test_create_team_reactivates_inactive_team -v
+```
+
+### Integration Tests Only
+```bash
+# Run all new integration tests
+python -m pytest tests/integration/test_player_interaction.py -k "create_team_automatically_reactivates_inactive or create_team_reactivation_preserves_team_id or create_team_vs_explicit_reactivate_identical_behavior or create_team_name_conflict_with_active_team" -v
+
+# Run specific integration test
+python -m pytest tests/integration/test_player_interaction.py::TestPlayerInteraction::test_create_team_automatically_reactivates_inactive -v
+```
+
+### All Tests
+```bash
+# Run all team management tests
+python -m pytest tests/unit/test_team_management.py tests/integration/test_player_interaction.py -v
+```
+
+## Benefits of This Testing Coverage
+
+1. **Comprehensive Validation**: Every aspect of the feature is tested from unit to integration level
+2. **Regression Prevention**: Future changes won't break the conflict resolution logic
+3. **Documentation**: Tests serve as living documentation of expected behavior
+4. **Confidence**: Developers can modify related code knowing tests will catch issues
+5. **User Experience Validation**: Integration tests ensure the feature works from user perspective
+
+## Future Test Considerations
+
+- **Load Testing**: High concurrency scenarios with multiple simultaneous reactivations
+- **Performance Testing**: Impact of checking inactive teams on team creation performance
+- **Browser Testing**: Client-side handling of `is_reactivated` flag
+- **Dashboard Testing**: Real-time updates when teams are automatically reactivated
+
+This testing suite ensures the team name conflict resolution feature is robust, reliable, and maintains the expected user experience while preventing the original duplicate team name bug.

--- a/tests/unit/test_team_management.py
+++ b/tests/unit/test_team_management.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch, ANY, MagicMock
 from flask import request
 from src.config import app, socketio, db
-from src.models.quiz_models import Teams
+from src.models.quiz_models import Teams, PairQuestionRounds
 from src.state import state
 import warnings
 from typing import Dict, Any
@@ -286,6 +286,177 @@ def test_create_team_duplicate_name(mock_request_context, active_team):
             'error',
             {'message': 'Team name already exists or is active'}
         )
+
+def test_create_team_reactivates_inactive_team(mock_request_context, inactive_team):
+    """Test team creation automatically reactivates inactive team with same name"""
+    with patch('src.sockets.team_management.emit') as mock_emit, \
+         patch('src.sockets.team_management.socketio.emit') as mock_socketio_emit, \
+         patch('src.sockets.dashboard.emit_dashboard_team_update') as mock_dashboard_update, \
+         patch('src.sockets.team_management.join_room') as mock_join_room:
+        
+        from src.sockets.team_management import on_create_team
+        on_create_team({'team_name': 'test_team'})
+        
+        # Verify team was reactivated in database
+        team = Teams.query.filter_by(team_id=inactive_team.team_id).first()
+        assert team.is_active == True
+        assert team.player1_session_id == 'test_sid'
+        
+        # Verify state updates
+        assert "test_team" in state.active_teams
+        assert state.active_teams["test_team"]["team_id"] == inactive_team.team_id
+        assert 'test_sid' in state.active_teams["test_team"]["players"]
+        assert state.active_teams["test_team"]["status"] == "waiting_pair"
+        assert state.player_to_team['test_sid'] == "test_team"
+        
+        # Verify event emissions include reactivation flag
+        mock_emit.assert_any_call(
+            'team_created',
+            {
+                'team_name': 'test_team',
+                'team_id': inactive_team.team_id,
+                'message': 'Team reactivated successfully. Waiting for another player.',
+                'game_started': state.game_started,
+                'game_mode': state.game_mode,
+                'player_slot': 1,
+                'is_reactivated': True  # This flag indicates automatic reactivation
+            }
+        )
+        
+        mock_socketio_emit.assert_any_call(
+            'teams_updated',
+            {
+                'teams': ANY,
+                'game_started': state.game_started
+            }
+        )
+        
+        # Verify dashboard update was called
+        mock_dashboard_update.assert_called_once()
+
+def test_create_team_reactivation_failure_fallback(mock_request_context, inactive_team):
+    """Test team creation falls back to error when reactivation fails"""
+    with patch('src.sockets.team_management.emit') as mock_emit, \
+         patch('src.sockets.team_management._reactivate_team_internal') as mock_reactivate:
+        
+        # Mock reactivation failure
+        mock_reactivate.return_value = False
+        
+        from src.sockets.team_management import on_create_team
+        on_create_team({'team_name': 'test_team'})
+        
+        # Should attempt reactivation
+        mock_reactivate.assert_called_once_with('test_team', 'test_sid')
+        
+        # Should emit error when reactivation fails
+        mock_emit.assert_called_once_with(
+            'error',
+            {'message': 'An error occurred while reactivating the team'}
+        )
+
+def test_reactivate_team_internal_success(mock_request_context, inactive_team):
+    """Test _reactivate_team_internal helper function success"""
+    from src.sockets.team_management import _reactivate_team_internal
+    
+    with patch('src.sockets.dashboard.clear_team_caches') as mock_clear_caches, \
+         patch('src.sockets.team_management.join_room') as mock_join_room:
+        
+        # Initial state check
+        assert "test_team" not in state.active_teams
+        
+        # Call the internal function
+        result = _reactivate_team_internal('test_team', 'test_sid')
+        
+        # Should return True for success
+        assert result == True
+        
+        # Verify team was updated in database
+        team = Teams.query.filter_by(team_id=inactive_team.team_id).first()
+        assert team.is_active == True
+        assert team.player1_session_id == 'test_sid'
+        
+        # Verify state updates
+        assert "test_team" in state.active_teams
+        assert state.active_teams["test_team"]["team_id"] == inactive_team.team_id
+        assert 'test_sid' in state.active_teams["test_team"]["players"]
+        assert state.active_teams["test_team"]["status"] == "waiting_pair"
+        assert state.player_to_team['test_sid'] == "test_team"
+        assert state.team_id_to_name[inactive_team.team_id] == "test_team"
+        
+        # Verify cache clearing and room joining
+        mock_clear_caches.assert_called_once()
+        mock_join_room.assert_called_once_with('test_team', sid='test_sid')
+
+def test_reactivate_team_internal_team_not_found(mock_request_context):
+    """Test _reactivate_team_internal returns False when team doesn't exist"""
+    from src.sockets.team_management import _reactivate_team_internal
+    
+    result = _reactivate_team_internal('nonexistent_team', 'test_sid')
+    assert result == False
+
+def test_reactivate_team_internal_name_conflict(mock_request_context, inactive_team):
+    """Test _reactivate_team_internal returns False when active team exists with same name"""
+    from src.sockets.team_management import _reactivate_team_internal
+    
+    # Set up conflicting active team
+    state.active_teams['test_team'] = {
+        'players': ['other_sid'],
+        'team_id': 999,
+        'status': 'waiting_pair'
+    }
+    
+    result = _reactivate_team_internal('test_team', 'test_sid')
+    assert result == False
+
+def test_reactivate_team_internal_preserves_round_history(mock_request_context, inactive_team):
+    """Test _reactivate_team_internal preserves previous round history"""
+    from src.sockets.team_management import _reactivate_team_internal
+    from src.models.quiz_models import ItemEnum
+    
+    # Add some round history to the inactive team
+    round1 = PairQuestionRounds(
+        team_id=inactive_team.team_id,
+        round_number_for_team=1,
+        player1_item=ItemEnum.A,
+        player2_item=ItemEnum.B
+    )
+    round2 = PairQuestionRounds(
+        team_id=inactive_team.team_id,
+        round_number_for_team=2,
+        player1_item=ItemEnum.X,
+        player2_item=ItemEnum.Y
+    )
+    db.session.add(round1)
+    db.session.add(round2)
+    db.session.commit()
+    
+    with patch('src.sockets.dashboard.clear_team_caches') as mock_clear_caches, \
+         patch('src.sockets.team_management.join_room') as mock_join_room:
+        
+        result = _reactivate_team_internal('test_team', 'test_sid')
+        
+        assert result == True
+        
+        # Verify round history is preserved in state
+        assert state.active_teams["test_team"]["current_round_number"] == 2
+        
+        # Cleanup
+        db.session.delete(round1)
+        db.session.delete(round2)
+        db.session.commit()
+
+def test_reactivate_team_internal_exception_handling(mock_request_context, inactive_team):
+    """Test _reactivate_team_internal handles exceptions gracefully"""
+    from src.sockets.team_management import _reactivate_team_internal
+    
+    with patch('src.sockets.team_management.db.session.commit') as mock_commit:
+        # Mock a database error
+        mock_commit.side_effect = Exception("Database error")
+        
+        result = _reactivate_team_internal('test_team', 'test_sid')
+        
+        # Should return False on exception
+        assert result == False
 
 def test_join_team_success(mock_request_context, active_team):
     """Test successful team join"""

--- a/tests/unit/test_team_management.py
+++ b/tests/unit/test_team_management.py
@@ -131,7 +131,8 @@ def test_reactivate_team_success(mock_request_context, inactive_team):
                 'message': 'Team reactivated successfully. Waiting for another player.',
                 'game_started': state.game_started,
                 'game_mode': state.game_mode,
-                'player_slot': 1  # Player reactivating is assigned to slot 1
+                'player_slot': 1,  # Player reactivating is assigned to slot 1
+                'is_reactivated': True  # Flag to indicate this was a reactivation
             }
         )
         


### PR DESCRIPTION
Implement automatic reactivation of inactive teams to prevent name conflicts and preserve team history.