### PR TITLE
Check dashboard data communication frequency

### DIFF
--- a/src/game_logic.py
+++ b/src/game_logic.py
@@ -104,8 +104,8 @@ def start_new_round_for_pair(team_name):
         db.session.commit()
         
         # Clear caches after database commit
-        from src.sockets.dashboard import clear_team_caches
-        clear_team_caches()
+        from src.sockets.dashboard import invalidate_team_caches
+        invalidate_team_caches(team_name)
 
         team_info['current_db_round_id'] = new_round_db.round_id
         team_info['answered_current_round'] = {}


### PR DESCRIPTION
Use selective cache invalidation to ensure dashboard team stats are properly throttled.

Previously, `start_new_round_for_pair` used `clear_team_caches()` which globally reset dashboard update throttling timers. This caused team-specific stats (like current round) to update instantly instead of respecting the 1-second `REFRESH_DELAY_QUICK` throttle. Switching to `invalidate_team_caches(team_name)` ensures only relevant caches are cleared while preserving throttling.