### PR TITLE
feat: add cheat detection foundations

### DIFF
--- a/src/cheats.py
+++ b/src/cheats.py
@@ -1,0 +1,54 @@
+import re
+from typing import Literal, Optional, Tuple
+from src.models.quiz_models import ItemEnum
+
+CHEAT_RE = re.compile(r"^cheat-(com|hint|tony|kevin)(?:$|[-_\s].*)", re.IGNORECASE)
+
+
+def parse_cheat_type(team_name: Optional[str]) -> str:
+    """Parse cheat type from team name.
+
+    Returns one of 'com', 'hint', 'tony', 'kevin', or 'none'.
+    Parsing is case-insensitive and tolerant of extra suffixes.
+    """
+    try:
+        name = (team_name or "").strip()
+        match = CHEAT_RE.match(name)
+        if not match:
+            return "none"
+        return match.group(1).lower()
+    except Exception:
+        return "none"
+
+
+def get_required_parity(
+    p1_item: ItemEnum, p2_item: ItemEnum
+) -> Literal["same", "different"]:
+    """Determine the required parity for a pair of items."""
+    try:
+        items = {p1_item, p2_item}
+        return "different" if ItemEnum.B in items and ItemEnum.Y in items else "same"
+    except Exception:
+        return "same"
+
+
+def recommend_answers(
+    parity: str, known_left: Optional[bool] = None, known_right: Optional[bool] = None
+) -> Tuple[bool, bool]:
+    """Recommend answers for players based on parity and known answers."""
+    if parity not in {"same", "different"}:
+        parity = "same"
+
+    if known_left is not None:
+        left = known_left
+        right = known_left if parity == "same" else not known_left
+        return left, right
+
+    if known_right is not None:
+        right = known_right
+        left = known_right if parity == "same" else not known_right
+        return left, right
+
+    if parity == "same":
+        return True, True
+    return True, False

--- a/src/sockets/team_management.py
+++ b/src/sockets/team_management.py
@@ -4,6 +4,7 @@ from flask_socketio import emit, join_room, leave_room
 from sqlalchemy import func
 from src.config import app, socketio, db
 from src.state import state
+from src.cheats import parse_cheat_type
 from src.models.quiz_models import Teams, PairQuestionRounds, Answers
 from src.game_logic import start_new_round_for_pair
 import logging
@@ -13,13 +14,15 @@ from typing import Dict, Any, List, Optional
 # Configure logging
 logger = logging.getLogger(__name__)
 
+
 def _get_player_slot_in_team(team_info: Dict[str, Any], sid: str) -> Optional[int]:
     """Get which player slot (1 or 2) a session ID occupies in a team"""
     try:
-        player_index = team_info['players'].index(sid)
+        player_index = team_info["players"].index(sid)
         return player_index + 1
     except (ValueError, KeyError):
         return None
+
 
 def _get_actual_player_slot(team_id: int, sid: str) -> Optional[int]:
     """Get the actual database slot (1 or 2) for a session ID"""
@@ -27,7 +30,7 @@ def _get_actual_player_slot(team_id: int, sid: str) -> Optional[int]:
         db_team = db.session.get(Teams, team_id)
         if not db_team:
             return None
-        
+
         if db_team.player1_session_id == sid:
             return 1
         elif db_team.player2_session_id == sid:
@@ -38,153 +41,203 @@ def _get_actual_player_slot(team_id: int, sid: str) -> Optional[int]:
         logger.error(f"Error getting actual player slot: {str(e)}")
         return None
 
-def _track_disconnected_player(team_name: str, sid: str, team_info: Dict[str, Any]) -> None:
+
+def _track_disconnected_player(
+    team_name: str, sid: str, team_info: Dict[str, Any]
+) -> None:
     """Track a disconnected player for potential reconnection"""
     player_slot = _get_player_slot_in_team(team_info, sid)
     if player_slot:
         state.disconnected_players[team_name] = {
-            'player_session_id': sid,
-            'player_slot': player_slot,
-            'disconnect_time': time.time()
+            "player_session_id": sid,
+            "player_slot": player_slot,
+            "disconnect_time": time.time(),
         }
-        logger.info(f"Tracking disconnected player {sid} from team {team_name} (slot {player_slot})")
+        logger.info(
+            f"Tracking disconnected player {sid} from team {team_name} (slot {player_slot})"
+        )
+
 
 def _clear_disconnected_player_tracking(team_name: str) -> None:
     """Clear tracking for a disconnected player"""
     if team_name in state.disconnected_players:
         del state.disconnected_players[team_name]
 
+
 def _can_rejoin_team(team_name: str) -> bool:
     """Check if a player can rejoin a team based on disconnection tracking"""
     if team_name not in state.disconnected_players:
         return False
-    
+
     team_info = state.active_teams.get(team_name)
     if not team_info:
         return False
-    
+
     # Team must be waiting for a player and have exactly one player
-    return len(team_info['players']) == 1 and team_info.get('status') == 'waiting_pair'
+    return len(team_info["players"]) == 1 and team_info.get("status") == "waiting_pair"
+
 
 def _reactivate_team_internal(team_name: str, sid: str) -> bool:
-    """
-    Internal helper to reactivate an inactive team.
-    Returns True if successful, False otherwise.
-    """
+    """Internal helper to reactivate an inactive team."""
     try:
-        # Find the inactive team in the database
+        cheat_type = parse_cheat_type(team_name)
+        if state.cheats_banned and cheat_type != "none":
+            return False
+
         team = Teams.query.filter_by(team_name=team_name, is_active=False).first()
         if not team:
             return False
-            
-        # Check if team name would conflict with any active team
+
         if team_name in state.active_teams:
             return False
-            
-        # Reactivate the team
+
         team.is_active = True
         team.player1_session_id = sid
         db.session.commit()
-        # Clear caches after team state change
         _, _, clear_team_caches, _, _ = _import_dashboard_functions()
         clear_team_caches()
 
-        # Query for the highest round number previously played by this team
-        max_round_obj = db.session.query(func.max(PairQuestionRounds.round_number_for_team)) \
-                                    .filter_by(team_id=team.team_id).scalar()
+        max_round_obj = (
+            db.session.query(func.max(PairQuestionRounds.round_number_for_team))
+            .filter_by(team_id=team.team_id)
+            .scalar()
+        )
         last_played_round_number = max_round_obj if max_round_obj is not None else 0
-        
-        # Set up team state
+
         state.active_teams[team_name] = {
-            'players': [sid],
-            'team_id': team.team_id,
-            'current_round_number': last_played_round_number,
-            'combo_tracker': {},
-            'answered_current_round': {},
-            'status': 'waiting_pair',
-            'player_slots': {sid: 1}  # Reactivator becomes Player 1
+            "players": [sid],
+            "team_id": team.team_id,
+            "current_round_number": last_played_round_number,
+            "combo_tracker": {},
+            "answered_current_round": {},
+            "status": "waiting_pair",
+            "player_slots": {sid: 1},
+            "cheat_type": cheat_type,
+            "cached_round_parity": None,
         }
         state.player_to_team[sid] = team_name
         state.team_id_to_name[team.team_id] = team_name
-        
+
         join_room(team_name, sid=sid)  # type: ignore
-        
+
+        if cheat_type != "none":
+            logger.info(f"Reactivated cheat team {team_name} as {cheat_type}")
+
         return True
     except Exception as e:
         logger.error(f"Error in _reactivate_team_internal: {str(e)}", exc_info=True)
         return False
 
+
 def _import_dashboard_functions():
     """Import dashboard functions to avoid circular import"""
-    from src.sockets.dashboard import emit_dashboard_team_update, emit_dashboard_full_update, clear_team_caches, handle_dashboard_disconnect, invalidate_team_caches
-    return emit_dashboard_team_update, emit_dashboard_full_update, clear_team_caches, handle_dashboard_disconnect, invalidate_team_caches
+    from src.sockets.dashboard import (
+        emit_dashboard_team_update,
+        emit_dashboard_full_update,
+        clear_team_caches,
+        handle_dashboard_disconnect,
+        invalidate_team_caches,
+    )
+
+    return (
+        emit_dashboard_team_update,
+        emit_dashboard_full_update,
+        clear_team_caches,
+        handle_dashboard_disconnect,
+        invalidate_team_caches,
+    )
+
 
 def get_available_teams_list() -> List[Dict[str, Any]]:
     try:
         # Get active teams that aren't full
-        active_teams = [{'team_name': name, 'team_id': info['team_id'], 'is_active': True}
-                       for name, info in state.active_teams.items() if len(info['players']) < 2]
-        
+        active_teams = [
+            {"team_name": name, "team_id": info["team_id"], "is_active": True}
+            for name, info in state.active_teams.items()
+            if len(info["players"]) < 2
+        ]
+
         # Get inactive teams from database (only if we have an app context)
         inactive_teams_list = []
         try:
             # Check if we're already in an app context, if not, create one
             if has_app_context():
                 inactive_teams = Teams.query.filter_by(is_active=False).all()
-                inactive_teams_list = [{'team_name': team.team_name, 'team_id': team.team_id, 'is_active': False}
-                                     for team in inactive_teams]
+                inactive_teams_list = [
+                    {
+                        "team_name": team.team_name,
+                        "team_id": team.team_id,
+                        "is_active": False,
+                    }
+                    for team in inactive_teams
+                ]
             else:
                 with app.app_context():
                     inactive_teams = Teams.query.filter_by(is_active=False).all()
-                    inactive_teams_list = [{'team_name': team.team_name, 'team_id': team.team_id, 'is_active': False}
-                                         for team in inactive_teams]
+                    inactive_teams_list = [
+                        {
+                            "team_name": team.team_name,
+                            "team_id": team.team_id,
+                            "is_active": False,
+                        }
+                        for team in inactive_teams
+                    ]
         except Exception as db_error:
             logger.warning(f"Could not fetch inactive teams: {str(db_error)}")
             inactive_teams_list = []
-        
+
         # Combine and return all teams
         return active_teams + inactive_teams_list
     except Exception as e:
         logger.error(f"Error in get_available_teams_list: {str(e)}", exc_info=True)
         return []
 
+
 def get_team_members(team_name: str) -> List[str]:
     try:
         team_info = state.active_teams.get(team_name)
-        if not team_info: return []
-        return team_info['players']
+        if not team_info:
+            return []
+        return team_info["players"]
     except Exception as e:
         logger.error(f"Error in get_team_members: {str(e)}", exc_info=True)
         return []
 
-@socketio.on('connect')
+
+@socketio.on("connect")
 def handle_connect() -> None:
     try:
         sid = request.sid  # type: ignore
-        logger.info(f'Client connected: {sid}')
-        
+        logger.info(f"Client connected: {sid}")
+
         # By default, treat all non-dashboard connections as players
         if sid not in state.dashboard_clients:
             state.connected_players.add(sid)
             _, emit_dashboard_full_update, _, _, _ = _import_dashboard_functions()
             emit_dashboard_full_update()  # Use full update to refresh player count
-        
-        emit('connection_established', {
-            'game_started': state.game_started,
-            'available_teams': get_available_teams_list(),
-            'game_mode': state.game_mode,
-            'game_theme': state.game_theme
-        })  # type: ignore
+
+        emit(
+            "connection_established",
+            {
+                "game_started": state.game_started,
+                "available_teams": get_available_teams_list(),
+                "game_mode": state.game_mode,
+                "game_theme": state.game_theme,
+            },
+        )  # type: ignore
     except Exception as e:
         logger.error(f"Error in handle_connect: {str(e)}", exc_info=True)
 
-@socketio.on('disconnect')
+
+@socketio.on("disconnect")
 def handle_disconnect() -> None:
     sid = request.sid  # type: ignore
-    logger.info(f'Client disconnected: {sid}')
+    logger.info(f"Client disconnected: {sid}")
     try:
         # Handle dashboard client disconnection
-        _, emit_dashboard_full_update, _, handle_dashboard_disconnect, _ = _import_dashboard_functions()
+        _, emit_dashboard_full_update, _, handle_dashboard_disconnect, _ = (
+            _import_dashboard_functions()
+        )
         handle_dashboard_disconnect(sid)
 
         # Remove from connected players list regardless of team status
@@ -198,198 +251,239 @@ def handle_disconnect() -> None:
             team_info = state.active_teams.get(team_name)
             if team_info:
                 # Using Session.get() instead of Query.get()
-                db_team = db.session.get(Teams, team_info['team_id'])
+                db_team = db.session.get(Teams, team_info["team_id"])
                 if db_team:
                     # Check if the team was full before this player disconnected
-                    was_full_team = len(team_info['players']) == 2
+                    was_full_team = len(team_info["players"]) == 2
 
                     # Remove player from team
-                    if sid in team_info['players']:
+                    if sid in team_info["players"]:
                         # Track disconnected player for potential reconnection
                         if was_full_team:
                             _track_disconnected_player(team_name, sid, team_info)
-                        
-                        team_info['players'].remove(sid)
-                        
+
+                        team_info["players"].remove(sid)
+
                         # Update the database
                         if db_team.player1_session_id == sid:
                             db_team.player1_session_id = None
                         elif db_team.player2_session_id == sid:
                             db_team.player2_session_id = None
-                            
+
                         # Leave the team room BEFORE emitting to the team
                         try:
                             leave_room(team_name, sid=sid)
                         except Exception as e:
                             logger.error(f"Error leaving room: {str(e)}")
-                            
+
                         # Notify remaining players and update team status
-                        remaining_players = team_info['players']
+                        remaining_players = team_info["players"]
                         if remaining_players:
                             # Always update status to waiting_pair when there's only one player
-                            team_info['status'] = 'waiting_pair'
-                            
-                            emit('player_left', {'message': 'A team member has disconnected.'}, to=team_name)  # type: ignore
+                            team_info["status"] = "waiting_pair"
+
+                            emit("player_left", {"message": "A team member has disconnected."}, to=team_name)  # type: ignore
                             # Keep team active with remaining player, but disable response input
-                            emit('team_status_update', {
-                                'team_name': team_name,
-                                'status': 'waiting_pair',
-                                'members': remaining_players,
-                                'game_started': state.game_started,
-                                'disable_input': True  # Disable response input when team is incomplete
-                            }, to=team_name)  # type: ignore
+                            emit(
+                                "team_status_update",
+                                {
+                                    "team_name": team_name,
+                                    "status": "waiting_pair",
+                                    "members": remaining_players,
+                                    "game_started": state.game_started,
+                                    "disable_input": True,  # Disable response input when team is incomplete
+                                },
+                                to=team_name,
+                            )  # type: ignore
                         else:
                             # If no players left, mark team as inactive and clear tracking
                             _clear_disconnected_player_tracking(team_name)
-                            existing_inactive = Teams.query.filter_by(team_name=team_name, is_active=False).first()
+                            existing_inactive = Teams.query.filter_by(
+                                team_name=team_name, is_active=False
+                            ).first()
                             if existing_inactive:
                                 db_team.team_name = f"{team_name}_{db_team.team_id}"
                             db_team.is_active = False
                             # Remove from active_teams state only if it exists
                             if team_name in state.active_teams:
                                 del state.active_teams[team_name]
-                            if team_info['team_id'] in state.team_id_to_name:
-                                del state.team_id_to_name[team_info['team_id']]
-                        
+                            if team_info["team_id"] in state.team_id_to_name:
+                                del state.team_id_to_name[team_info["team_id"]]
+
                         db.session.commit()
                         # Selectively invalidate caches for the affected team only
-                        _, _, _, _, invalidate_team_caches = _import_dashboard_functions()
+                        _, _, _, _, invalidate_team_caches = (
+                            _import_dashboard_functions()
+                        )
                         invalidate_team_caches(team_name)
-                        
+
                         del state.player_to_team[sid]
-                        
+
                         # Update all clients - this should happen regardless of whether team becomes inactive
                         # Move dashboard update to end to ensure all state changes are committed
-                        emit_dashboard_team_update, _, _, _, _ = _import_dashboard_functions()
+                        emit_dashboard_team_update, _, _, _, _ = (
+                            _import_dashboard_functions()
+                        )
                         emit_dashboard_team_update()
-                        socketio.emit('teams_updated', {
-                            'teams': get_available_teams_list(),
-                            'game_started': state.game_started
-                        })  # type: ignore
+                        socketio.emit(
+                            "teams_updated",
+                            {
+                                "teams": get_available_teams_list(),
+                                "game_started": state.game_started,
+                            },
+                        )  # type: ignore
     except Exception as e:
         logger.error(f"Disconnect handler error: {str(e)}", exc_info=True)
 
-@socketio.on('create_team')
+
+@socketio.on("create_team")
 def on_create_team(data: Dict[str, Any]) -> None:
     try:
-        team_name = data.get('team_name')
+        team_name = data.get("team_name")
         sid = request.sid  # type: ignore
         if not team_name:
-            emit('error', {'message': 'Team name is required'})  # type: ignore
+            emit("error", {"message": "Team name is required"})  # type: ignore
             return
-            
+
+        cheat_type = parse_cheat_type(team_name)
+        if state.cheats_banned and cheat_type != "none":
+            emit("error", {"message": "Cheats are currently disabled"})  # type: ignore
+            return
+
         # Check if team name already exists as active team
-        if team_name in state.active_teams or Teams.query.filter_by(team_name=team_name, is_active=True).first():
-            emit('error', {'message': 'Team name already exists or is active'})  # type: ignore
+        if (
+            team_name in state.active_teams
+            or Teams.query.filter_by(team_name=team_name, is_active=True).first()
+        ):
+            emit("error", {"message": "Team name already exists or is active"})  # type: ignore
             return
 
         # Check if team name exists as inactive team - if so, reactivate it
-        inactive_team = Teams.query.filter_by(team_name=team_name, is_active=False).first()
+        inactive_team = Teams.query.filter_by(
+            team_name=team_name, is_active=False
+        ).first()
         if inactive_team:
             # Attempt to reactivate the existing inactive team
             if _reactivate_team_internal(team_name, sid):
                 team_info = state.active_teams[team_name]
-                emit('team_created', {
-                    'team_name': team_name,
-                    'team_id': team_info['team_id'],
-                    'message': 'Team reactivated successfully. Waiting for another player.',
-                    'game_started': state.game_started,
-                    'game_mode': state.game_mode,
-                    'game_theme': state.game_theme,
-                    'player_slot': 1,
-                    'is_reactivated': True  # Flag to indicate this was a reactivation
-                })  # type: ignore
-                emit('team_status_update', {'status': 'created'}, to=request.sid)  # type: ignore
-                
-                socketio.emit('teams_updated', {
-                    'teams': get_available_teams_list(),
-                    'game_started': state.game_started
-                })  # type: ignore
-                
+                emit(
+                    "team_created",
+                    {
+                        "team_name": team_name,
+                        "team_id": team_info["team_id"],
+                        "message": "Team reactivated successfully. Waiting for another player.",
+                        "game_started": state.game_started,
+                        "game_mode": state.game_mode,
+                        "game_theme": state.game_theme,
+                        "player_slot": 1,
+                        "is_reactivated": True,  # Flag to indicate this was a reactivation
+                    },
+                )  # type: ignore
+                emit("team_status_update", {"status": "created"}, to=request.sid)  # type: ignore
+
+                socketio.emit(
+                    "teams_updated",
+                    {
+                        "teams": get_available_teams_list(),
+                        "game_started": state.game_started,
+                    },
+                )  # type: ignore
+
                 emit_dashboard_team_update, _, _, _, _ = _import_dashboard_functions()
                 emit_dashboard_team_update()
                 return
             else:
-                emit('error', {'message': 'An error occurred while reactivating the team'})  # type: ignore
+                emit("error", {"message": "An error occurred while reactivating the team"})  # type: ignore
                 return
 
         # Create new team if no existing team found
-        new_team_db = Teams(
-            team_name=team_name,
-            player1_session_id=sid
-        )
+        new_team_db = Teams(team_name=team_name, player1_session_id=sid)
         db.session.add(new_team_db)
         db.session.commit()
         # Selectively invalidate caches for the new team only
         _, _, _, _, invalidate_team_caches = _import_dashboard_functions()
         invalidate_team_caches(team_name)
         state.active_teams[team_name] = {
-            'players': [sid],
-            'team_id': new_team_db.team_id,
-            'current_round_number': 0,
-            'combo_tracker': {},
-            'answered_current_round': {},
-            'status': 'waiting_pair',
-            'player_slots': {sid: 1}  # Creator is always Player 1
+            "players": [sid],
+            "team_id": new_team_db.team_id,
+            "current_round_number": 0,
+            "combo_tracker": {},
+            "answered_current_round": {},
+            "status": "waiting_pair",
+            "player_slots": {sid: 1},
+            "cheat_type": cheat_type,
+            "cached_round_parity": None,
         }
         state.player_to_team[sid] = team_name
         state.team_id_to_name[new_team_db.team_id] = team_name
         join_room(team_name, sid=sid)  # type: ignore
-        
-        emit('team_created', {
-            'team_name': team_name,
-            'team_id': new_team_db.team_id,
-            'message': 'Team created. Waiting for another player.',
-            'game_started': state.game_started,
-            'game_mode': state.game_mode,
-            'game_theme': state.game_theme,
-            'player_slot': 1  # Creator is always assigned to player1_session_id (slot 1)
-        })  # type: ignore
+
+        if cheat_type != "none":
+            logger.info(f"Team {team_name} created with cheat_type={cheat_type}")
+
+        emit(
+            "team_created",
+            {
+                "team_name": team_name,
+                "team_id": new_team_db.team_id,
+                "message": "Team created. Waiting for another player.",
+                "game_started": state.game_started,
+                "game_mode": state.game_mode,
+                "game_theme": state.game_theme,
+                "player_slot": 1,  # Creator is always assigned to player1_session_id (slot 1)
+            },
+        )  # type: ignore
         # This team_status_update for 'created' seems specific to the creator,
         # and might be redundant if 'team_created' already conveys enough.
         # Consider if this is still needed or if 'team_created' is sufficient.
         # For now, keeping it as it was.
-        emit('team_status_update', {'status': 'created'}, to=request.sid)  # type: ignore
-        
-        socketio.emit('teams_updated', {
-            'teams': get_available_teams_list(),
-            'game_started': state.game_started
-        })  # type: ignore
-        
+        emit("team_status_update", {"status": "created"}, to=request.sid)  # type: ignore
+
+        socketio.emit(
+            "teams_updated",
+            {"teams": get_available_teams_list(), "game_started": state.game_started},
+        )  # type: ignore
+
         emit_dashboard_team_update, _, _, _, _ = _import_dashboard_functions()
         emit_dashboard_team_update()
     except Exception as e:
         logger.error(f"Error in on_create_team: {str(e)}", exc_info=True)
-        emit('error', {'message': 'An error occurred while creating the team'})  # type: ignore
+        emit("error", {"message": "An error occurred while creating the team"})  # type: ignore
 
-@socketio.on('join_team')
+
+@socketio.on("join_team")
 def on_join_team(data: Dict[str, Any]) -> None:
     try:
-        team_name = data.get('team_name')
+        team_name = data.get("team_name")
         sid = request.sid  # type: ignore
         if not team_name or team_name not in state.active_teams:
-            emit('error', {'message': 'Team not found or invalid team name.'})  # type: ignore
+            emit("error", {"message": "Team not found or invalid team name."})  # type: ignore
             return
         team_info = state.active_teams[team_name]
-        if len(team_info['players']) >= 2:
-            emit('error', {'message': 'Team is already full.'})  # type: ignore
+        cheat_type = team_info.get("cheat_type") or parse_cheat_type(team_name)
+        team_info["cheat_type"] = cheat_type
+        if state.cheats_banned and cheat_type != "none":
+            emit("error", {"message": "Cheats are currently disabled"})  # type: ignore
             return
-        if sid in team_info['players']:
-            emit('error', {'message': 'You are already in this team.'})  # type: ignore
+        if len(team_info["players"]) >= 2:
+            emit("error", {"message": "Team is already full."})  # type: ignore
+            return
+        if sid in team_info["players"]:
+            emit("error", {"message": "You are already in this team."})  # type: ignore
             return
 
         # Check if this is a valid reconnection by matching session IDs
         is_valid_reconnection = False
         if team_name in state.disconnected_players:
             tracked_player = state.disconnected_players[team_name]
-            is_valid_reconnection = tracked_player['player_session_id'] == sid
-        
-        team_info['players'].append(sid)
+            is_valid_reconnection = tracked_player["player_session_id"] == sid
+
+        team_info["players"].append(sid)
         state.player_to_team[sid] = team_name
         join_room(team_name, sid=sid)  # type: ignore
-        
+
         # Using Session.get() instead of Query.get()
-        db_team = db.session.get(Teams, team_info['team_id'])
+        db_team = db.session.get(Teams, team_info["team_id"])
         assigned_slot = None
         if db_team:
             if not db_team.player1_session_id:
@@ -400,63 +494,79 @@ def on_join_team(data: Dict[str, Any]) -> None:
                 assigned_slot = 2
             db_team.is_active = True
             db.session.commit()
-            
+
             # Track player slot in state
             if assigned_slot:
                 state.set_player_slot(team_name, sid, assigned_slot)
-            
+
             # Selectively invalidate caches for the affected team only
             _, _, _, _, invalidate_team_caches = _import_dashboard_functions()
             invalidate_team_caches(team_name)
 
-        team_is_now_full = len(team_info['players']) == 2
-        current_team_status_for_clients = 'full' if team_is_now_full else 'waiting_pair'
-        
+        team_is_now_full = len(team_info["players"]) == 2
+        current_team_status_for_clients = "full" if team_is_now_full else "waiting_pair"
+
         if team_is_now_full:
-            team_info['status'] = 'active' # Internal state status
+            team_info["status"] = "active"  # Internal state status
             # Clear disconnection tracking when team becomes full
             if team_name in state.disconnected_players:
                 _clear_disconnected_player_tracking(team_name)
         else:
-            team_info['status'] = 'waiting_pair' # Internal state status
+            team_info["status"] = "waiting_pair"  # Internal state status
 
         # Get the actual player slot assigned in the database
-        actual_player_slot = assigned_slot or _get_actual_player_slot(team_info['team_id'], sid)
-        
+        actual_player_slot = assigned_slot or _get_actual_player_slot(
+            team_info["team_id"], sid
+        )
+
         # Notify the player who just joined - only treat as reconnection if SIDs match
-        join_message = f'You reconnected to team {team_name}.' if is_valid_reconnection else f'You joined team {team_name}.'
-        emit('team_joined', {
-            'team_name': team_name,
-            'message': join_message,
-            'game_started': state.game_started,
-            'team_status': current_team_status_for_clients,
-            'is_reconnection': is_valid_reconnection,
-            'game_mode': state.game_mode,
-            'game_theme': state.game_theme,
-            'player_slot': actual_player_slot
-        }, to=sid)  # type: ignore
-        
+        join_message = (
+            f"You reconnected to team {team_name}."
+            if is_valid_reconnection
+            else f"You joined team {team_name}."
+        )
+        emit(
+            "team_joined",
+            {
+                "team_name": team_name,
+                "message": join_message,
+                "game_started": state.game_started,
+                "team_status": current_team_status_for_clients,
+                "is_reconnection": is_valid_reconnection,
+                "game_mode": state.game_mode,
+                "game_theme": state.game_theme,
+                "player_slot": actual_player_slot,
+            },
+            to=sid,
+        )  # type: ignore
+
         # Notify all team members (including the one who just joined) about the team's current state
         # This replaces the separate 'player_joined' and multiple 'team_status_update' emits
-        emit('team_status_update', {
-            'team_name': team_name,
-            'status': current_team_status_for_clients,
-            'members': get_team_members(team_name),
-            'game_started': state.game_started,
-            'disable_input': False if team_is_now_full else True  # Enable input only when team is full
-        }, to=team_name)  # type: ignore
-        
+        emit(
+            "team_status_update",
+            {
+                "team_name": team_name,
+                "status": current_team_status_for_clients,
+                "members": get_team_members(team_name),
+                "game_started": state.game_started,
+                "disable_input": (
+                    False if team_is_now_full else True
+                ),  # Enable input only when team is full
+            },
+            to=team_name,
+        )  # type: ignore
+
         # Update all clients about the list of available teams
-        socketio.emit('teams_updated', {
-            'teams': get_available_teams_list(),
-            'game_started': state.game_started
-        })  # type: ignore
-        
+        socketio.emit(
+            "teams_updated",
+            {"teams": get_available_teams_list(), "game_started": state.game_started},
+        )  # type: ignore
+
         # Update dashboard
         # Force refresh when team becomes active (critical state change)
         emit_dashboard_team_update, _, _, _, _ = _import_dashboard_functions()
         emit_dashboard_team_update()
-        
+
         # If the game has already started and the team is now full, start a new round for them
         if state.game_started and team_is_now_full:
             start_new_round_for_pair(team_name)
@@ -467,176 +577,203 @@ def on_join_team(data: Dict[str, Any]) -> None:
 
     except Exception as e:
         logger.error(f"Error in on_join_team: {str(e)}", exc_info=True)
-        emit('error', {'message': 'An error occurred while joining the team'})  # type: ignore
+        emit("error", {"message": "An error occurred while joining the team"})  # type: ignore
 
-@socketio.on('reactivate_team')
+
+@socketio.on("reactivate_team")
 def on_reactivate_team(data: Dict[str, Any]) -> None:
     try:
-        team_name = data.get('team_name')
+        team_name = data.get("team_name")
         sid = request.sid  # type: ignore
-        
+
         if not team_name:
-            emit('error', {'message': 'Team name is required'})  # type: ignore
+            emit("error", {"message": "Team name is required"})  # type: ignore
             return
-            
+
         # Check if team exists as inactive
-        inactive_team = Teams.query.filter_by(team_name=team_name, is_active=False).first()
+        inactive_team = Teams.query.filter_by(
+            team_name=team_name, is_active=False
+        ).first()
         if not inactive_team:
-            emit('error', {'message': 'Team not found or is already active'})  # type: ignore
+            emit("error", {"message": "Team not found or is already active"})  # type: ignore
             return
-            
+
         # Check if team name would conflict with any active team
         if team_name in state.active_teams:
-            emit('error', {'message': 'An active team with this name already exists'})  # type: ignore
+            emit("error", {"message": "An active team with this name already exists"})  # type: ignore
             return
-            
+
         # Use the internal reactivation helper
         if _reactivate_team_internal(team_name, sid):
             team_info = state.active_teams[team_name]
-            
-            emit('team_created', { # Client treats this like a new team creation
-                'team_name': team_name,
-                'team_id': team_info['team_id'],
-                'message': 'Team reactivated successfully. Waiting for another player.',
-                'game_started': state.game_started,
-                'game_mode': state.game_mode,
-                'game_theme': state.game_theme,
-                'player_slot': 1,  # Player reactivating team is assigned to player1_session_id (slot 1)
-                'is_reactivated': True  # Flag to indicate this was a reactivation
-            })  # type: ignore
-            
+
+            emit(
+                "team_created",
+                {  # Client treats this like a new team creation
+                    "team_name": team_name,
+                    "team_id": team_info["team_id"],
+                    "message": "Team reactivated successfully. Waiting for another player.",
+                    "game_started": state.game_started,
+                    "game_mode": state.game_mode,
+                    "game_theme": state.game_theme,
+                    "player_slot": 1,  # Player reactivating team is assigned to player1_session_id (slot 1)
+                    "is_reactivated": True,  # Flag to indicate this was a reactivation
+                },
+            )  # type: ignore
+
             # ADD THIS: Send team_status_update event to properly set team status
-            emit('team_status_update', {
-                'team_name': team_name,
-                'status': 'waiting_pair',
-                'members': get_team_members(team_name),
-                'game_started': state.game_started,
-                'disable_input': True  # Disable input when team is incomplete
-            }, to=team_name)  # type: ignore
-            
-            socketio.emit('teams_updated', {
-                'teams': get_available_teams_list(),
-                'game_started': state.game_started
-            })  # type: ignore
-            
+            emit(
+                "team_status_update",
+                {
+                    "team_name": team_name,
+                    "status": "waiting_pair",
+                    "members": get_team_members(team_name),
+                    "game_started": state.game_started,
+                    "disable_input": True,  # Disable input when team is incomplete
+                },
+                to=team_name,
+            )  # type: ignore
+
+            socketio.emit(
+                "teams_updated",
+                {
+                    "teams": get_available_teams_list(),
+                    "game_started": state.game_started,
+                },
+            )  # type: ignore
+
             emit_dashboard_team_update, _, _, _, _ = _import_dashboard_functions()
             emit_dashboard_team_update()
         else:
-            emit('error', {'message': 'An error occurred while reactivating the team'})  # type: ignore
-            
+            emit("error", {"message": "An error occurred while reactivating the team"})  # type: ignore
+
     except Exception as e:
         logger.error(f"Error in on_reactivate_team: {str(e)}", exc_info=True)
-        emit('error', {'message': 'An error occurred while reactivating the team'})  # type: ignore
+        emit("error", {"message": "An error occurred while reactivating the team"})  # type: ignore
 
-@socketio.on('get_reconnectable_teams')
+
+@socketio.on("get_reconnectable_teams")
 def on_get_reconnectable_teams(data: Dict[str, Any]) -> None:
     """Get list of teams that a player can reconnect to"""
     try:
         sid = request.sid  # type: ignore
         reconnectable_teams = []
-        
+
         # Find teams that are waiting for a player and have a disconnected player tracked
         for team_name, team_info in state.active_teams.items():
-            if (team_name in state.disconnected_players and 
-                len(team_info['players']) == 1 and 
-                team_info.get('status') == 'waiting_pair'):
+            if (
+                team_name in state.disconnected_players
+                and len(team_info["players"]) == 1
+                and team_info.get("status") == "waiting_pair"
+            ):
                 disconnected_info = state.disconnected_players[team_name]
-                reconnectable_teams.append({
-                    'team_name': team_name,
-                    'team_id': team_info['team_id'],
-                    'disconnect_time': disconnected_info['disconnect_time'],
-                    'player_slot': disconnected_info['player_slot']
-                })
-        
-        emit('reconnectable_teams', {'teams': reconnectable_teams})  # type: ignore
-        
+                reconnectable_teams.append(
+                    {
+                        "team_name": team_name,
+                        "team_id": team_info["team_id"],
+                        "disconnect_time": disconnected_info["disconnect_time"],
+                        "player_slot": disconnected_info["player_slot"],
+                    }
+                )
+
+        emit("reconnectable_teams", {"teams": reconnectable_teams})  # type: ignore
+
     except Exception as e:
         logger.error(f"Error in on_get_reconnectable_teams: {str(e)}", exc_info=True)
-        emit('error', {'message': 'An error occurred while getting reconnectable teams'})  # type: ignore
+        emit("error", {"message": "An error occurred while getting reconnectable teams"})  # type: ignore
 
-@socketio.on('leave_team')
+
+@socketio.on("leave_team")
 def on_leave_team(data: Dict[str, Any]) -> None:
     try:
         sid = request.sid  # type: ignore
         if sid not in state.player_to_team:
-            emit('error', {'message': 'You are not in a team.'})  # type: ignore
+            emit("error", {"message": "You are not in a team."})  # type: ignore
             return
         team_name = state.player_to_team[sid]
         team_info = state.active_teams.get(team_name)
         if not team_info:
-            if sid in state.player_to_team: # Check before deleting
-                 del state.player_to_team[sid]
-            emit('error', {'message': 'Team info not found, you have been removed.'})  # type: ignore
+            if sid in state.player_to_team:  # Check before deleting
+                del state.player_to_team[sid]
+            emit("error", {"message": "Team info not found, you have been removed."})  # type: ignore
             return
 
         # Using Session.get() instead of Query.get()
-        db_team = db.session.get(Teams, team_info['team_id'])
-        if sid in team_info['players']:
+        db_team = db.session.get(Teams, team_info["team_id"])
+        if sid in team_info["players"]:
             # Track disconnected player if this was a full team
-            was_full_team = len(team_info['players']) == 2
+            was_full_team = len(team_info["players"]) == 2
             if was_full_team:
                 _track_disconnected_player(team_name, sid, team_info)
-            
-            team_info['players'].remove(sid)
-            
+
+            team_info["players"].remove(sid)
+
             if db_team:
                 if db_team.player1_session_id == sid:
                     db_team.player1_session_id = None
                 elif db_team.player2_session_id == sid:
                     db_team.player2_session_id = None
 
-            if len(team_info['players']) > 0:
+            if len(team_info["players"]) > 0:
                 # Always set status to waiting_pair when there's only one player left
-                team_info['status'] = 'waiting_pair'
-                emit('player_left', {'message': 'A team member has left.'}, to=team_name)  # type: ignore
-                emit('team_status_update', {
-                    'team_name': team_name,
-                    'status': 'waiting_pair', 
-                    'members': get_team_members(team_name),
-                    'game_started': state.game_started,
-                    'disable_input': True  # Disable input when team becomes incomplete
-                }, to=team_name)  # type: ignore
+                team_info["status"] = "waiting_pair"
+                emit("player_left", {"message": "A team member has left."}, to=team_name)  # type: ignore
+                emit(
+                    "team_status_update",
+                    {
+                        "team_name": team_name,
+                        "status": "waiting_pair",
+                        "members": get_team_members(team_name),
+                        "game_started": state.game_started,
+                        "disable_input": True,  # Disable input when team becomes incomplete
+                    },
+                    to=team_name,
+                )  # type: ignore
             else:
                 # No players left, team becomes inactive and clear tracking
                 _clear_disconnected_player_tracking(team_name)
                 if team_name in state.active_teams:
                     del state.active_teams[team_name]
-                if team_info['team_id'] in state.team_id_to_name:
-                    del state.team_id_to_name[team_info['team_id']]
+                if team_info["team_id"] in state.team_id_to_name:
+                    del state.team_id_to_name[team_info["team_id"]]
                 if db_team:
                     # Check for name conflict before marking inactive
                     # This logic might be better placed in a shared utility if used elsewhere
                     existing_inactive_with_same_name = Teams.query.filter(
-                        Teams.team_name == team_name, 
+                        Teams.team_name == team_name,
                         Teams.is_active == False,
-                        Teams.team_id != db_team.team_id # Exclude itself if it was already inactive (should not happen here)
+                        Teams.team_id
+                        != db_team.team_id,  # Exclude itself if it was already inactive (should not happen here)
                     ).first()
                     if existing_inactive_with_same_name:
                         db_team.team_name = f"{team_name}_{db_team.team_id}"
                     db_team.is_active = False
-            
-            if db_team: # Commit changes if db_team was involved
+
+            if db_team:  # Commit changes if db_team was involved
                 db.session.commit()
                 # Selectively invalidate caches for the affected team only
                 _, _, _, _, invalidate_team_caches = _import_dashboard_functions()
                 invalidate_team_caches(team_name)
 
-            emit('left_team_success', {'message': 'You have left the team.'}, to=sid)  # type: ignore
+            emit("left_team_success", {"message": "You have left the team."}, to=sid)  # type: ignore
             try:
                 leave_room(team_name, sid=sid)
-            except Exception as e: # Catch potential error if room/sid is already gone
+            except Exception as e:  # Catch potential error if room/sid is already gone
                 logger.error(f"Error leaving room on leave_team: {str(e)}")
 
-            if sid in state.player_to_team: # Check before deleting
+            if sid in state.player_to_team:  # Check before deleting
                 del state.player_to_team[sid]
-            
-            socketio.emit('teams_updated', {
-                'teams': get_available_teams_list(),
-                'game_started': state.game_started
-            })  # type: ignore
+
+            socketio.emit(
+                "teams_updated",
+                {
+                    "teams": get_available_teams_list(),
+                    "game_started": state.game_started,
+                },
+            )  # type: ignore
             # Force refresh for critical team state changes like leaving
             emit_dashboard_team_update, _, _, _, _ = _import_dashboard_functions()
             emit_dashboard_team_update()
     except Exception as e:
         logger.error(f"Error in on_leave_team: {str(e)}", exc_info=True)
-        emit('error', {'message': 'An error occurred while leaving the team'})  # type: ignore
+        emit("error", {"message": "An error occurred while leaving the team"})  # type: ignore

--- a/src/state.py
+++ b/src/state.py
@@ -1,24 +1,30 @@
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
 
 class AppState:
     def __init__(self):
-        self.active_teams = {}  # {team_name: {'players': [], 'team_id': db_team_id, 'current_round_number': 0, 'combo_tracker': {}, 'current_db_round_id': None, 'answered_current_round': {}, 'player_slots': {sid: slot_number}}}
+        self.active_teams = (
+            {}
+        )  # {team_name: {'players': [], 'team_id': db_team_id, 'current_round_number': 0, 'combo_tracker': {}, 'current_db_round_id': None, 'answered_current_round': {}, 'player_slots': {sid: slot_number}, 'cheat_type': 'none', 'cached_round_parity': None}}
         self.player_to_team = {}  # {sid: team_name}
         self.connected_players = set()  # All connected player SIDs
-        self.dashboard_clients = set() # Stores SIDs of connected dashboard clients
-        self.game_started = False # Track if game has started
-        self.game_paused = False # Track if game is paused
-        self.answer_stream_enabled = False # Track if answer streaming is enabled
+        self.dashboard_clients = set()  # Stores SIDs of connected dashboard clients
+        self.game_started = False  # Track if game has started
+        self.game_paused = False  # Track if game is paused
+        self.answer_stream_enabled = False  # Track if answer streaming is enabled
+        self.cheats_banned = os.environ.get("CHEATS_DISABLED", "").lower() == "true"
         # Internal storage for game mode with normalization
-        self._game_mode = 'simplified'  # Track current game mode: 'classic', 'simplified', or 'aqmjoe'
-        self.game_theme = 'food'  # Track current game theme: 'classic', 'food', etc.
+        self._game_mode = "simplified"  # Track current game mode: 'classic', 'simplified', or 'aqmjoe'
+        self.game_theme = "food"  # Track current game theme: 'classic', 'food', etc.
         # Store team ID to team name mapping for faster lookups
-        self.team_id_to_name = {} # {team_id: team_name}
+        self.team_id_to_name = {}  # {team_id: team_name}
         # Track disconnected players for reconnection - maps team_name to disconnected player info
-        self.disconnected_players = {}  # {team_name: {'player_session_id': old_sid, 'player_slot': 1|2, 'disconnect_time': timestamp}}
+        self.disconnected_players = (
+            {}
+        )  # {team_name: {'player_session_id': old_sid, 'player_slot': 1|2, 'disconnect_time': timestamp}}
 
     @property
     def game_mode(self):
@@ -26,15 +32,19 @@ class AppState:
 
     @game_mode.setter
     def game_mode(self, value):
-        if value == 'new':
+        if value == "new":
             # Deprecated alias handling
-            logger.warning('Deprecated mode "new" encountered; falling back to "simplified"')
-            self._game_mode = 'simplified'
+            logger.warning(
+                'Deprecated mode "new" encountered; falling back to "simplified"'
+            )
+            self._game_mode = "simplified"
             return
-        if value in ('classic', 'simplified', 'aqmjoe'):
+        if value in ("classic", "simplified", "aqmjoe"):
             self._game_mode = value
         else:
-            logger.error(f"Unsupported game mode '{value}' provided; keeping previous mode '{self._game_mode}'")
+            logger.error(
+                f"Unsupported game mode '{value}' provided; keeping previous mode '{self._game_mode}'"
+            )
 
     def reset(self):
         self.active_teams.clear()
@@ -46,27 +56,30 @@ class AppState:
         self.game_started = False
         self.game_paused = False
         self.answer_stream_enabled = False
-        self.game_mode = 'simplified'  # Reset game mode to simplified
-        self.game_theme = 'food'  # Reset game theme to food
+        self.game_mode = "simplified"  # Reset game mode to simplified
+        self.game_theme = "food"  # Reset game theme to food
+        self.cheats_banned = os.environ.get("CHEATS_DISABLED", "").lower() == "true"
 
     def get_player_slot(self, team_name, sid):
         """Get the database player slot (1 or 2) for a session ID in a team"""
         team_info = self.active_teams.get(team_name)
         if not team_info:
             return None
-        return team_info.get('player_slots', {}).get(sid)
-    
+        return team_info.get("player_slots", {}).get(sid)
+
     def set_player_slot(self, team_name, sid, slot):
         """Set the database player slot for a session ID in a team"""
         team_info = self.active_teams.get(team_name)
         if team_info:
-            if 'player_slots' not in team_info:
-                team_info['player_slots'] = {}
-            team_info['player_slots'][sid] = slot
+            if "player_slots" not in team_info:
+                team_info["player_slots"] = {}
+            team_info["player_slots"][sid] = slot
+
 
 # Backwards‑compatibility alias for tests
 class GameState(AppState):
     pass
+
 
 # Create singleton instance for state
 state = AppState()

--- a/tests/integration/test_cheats_foundations.py
+++ b/tests/integration/test_cheats_foundations.py
@@ -1,0 +1,60 @@
+import eventlet
+
+# Patch sockets for eventlet
+eventlet.monkey_patch()
+
+import pytest
+from flask_socketio import SocketIOTestClient
+from src.config import app, socketio as server_socketio
+from src.state import state
+from src.models.quiz_models import Teams, PairQuestionRounds, Answers, db
+
+
+def reset_application_state():
+    with app.app_context():
+        Answers.query.delete()
+        PairQuestionRounds.query.delete()
+        Teams.query.delete()
+        db.session.commit()
+    state.reset()
+
+
+def test_cheat_team_creation_parses_type():
+    reset_application_state()
+    client = SocketIOTestClient(app, server_socketio)
+    client.emit("create_team", {"team_name": "cheat-com-foo"})
+    eventlet.sleep(0)
+    assert "cheat-com-foo" in state.active_teams
+    assert state.active_teams["cheat-com-foo"]["cheat_type"] == "com"
+    client.disconnect()
+
+
+def test_cheats_banned_blocks_cheat_teams():
+    reset_application_state()
+    state.cheats_banned = True
+    client = SocketIOTestClient(app, server_socketio)
+    client.emit("create_team", {"team_name": "cheat-hint-team"})
+    eventlet.sleep(0)
+    messages = client.get_received()
+    assert any(m["name"] == "error" for m in messages)
+
+    # Non-cheat team should still be allowed
+    client.emit("create_team", {"team_name": "honest-team"})
+    eventlet.sleep(0)
+    assert "honest-team" in state.active_teams
+    client.disconnect()
+
+    # Ban also blocks joining existing cheat teams
+    reset_application_state()
+    client1 = SocketIOTestClient(app, server_socketio)
+    client1.emit("create_team", {"team_name": "cheat-tony-foo"})
+    eventlet.sleep(0)
+    assert "cheat-tony-foo" in state.active_teams
+    state.cheats_banned = True
+    client2 = SocketIOTestClient(app, server_socketio)
+    client2.emit("join_team", {"team_name": "cheat-tony-foo"})
+    eventlet.sleep(0)
+    messages = client2.get_received()
+    assert any(m["name"] == "error" for m in messages)
+    client1.disconnect()
+    client2.disconnect()

--- a/tests/unit/test_cheats_utils.py
+++ b/tests/unit/test_cheats_utils.py
@@ -1,0 +1,31 @@
+import pytest
+from src.cheats import parse_cheat_type, get_required_parity, recommend_answers
+from src.models.quiz_models import ItemEnum
+
+
+def test_parse_cheat_type_cases():
+    assert parse_cheat_type("cheat-com-team") == "com"
+    assert parse_cheat_type("CHEAT-HINT foo") == "hint"
+    assert parse_cheat_type("cheat-tony") == "tony"
+    assert parse_cheat_type("cheat-kevin_bar") == "kevin"
+    assert parse_cheat_type("cheater") == "none"
+    assert parse_cheat_type("") == "none"
+    assert parse_cheat_type(None) == "none"
+
+
+def test_get_required_parity():
+    assert get_required_parity(ItemEnum.B, ItemEnum.Y) == "different"
+    assert get_required_parity(ItemEnum.Y, ItemEnum.B) == "different"
+    assert get_required_parity(ItemEnum.A, ItemEnum.X) == "same"
+
+
+def test_recommend_answers_defaults():
+    assert recommend_answers("same") == (True, True)
+    assert recommend_answers("different") == (True, False)
+
+
+def test_recommend_answers_with_known():
+    assert recommend_answers("same", known_left=True) == (True, True)
+    assert recommend_answers("different", known_left=True) == (True, False)
+    assert recommend_answers("same", known_right=False) == (False, False)
+    assert recommend_answers("different", known_right=False) == (True, False)


### PR DESCRIPTION
## Summary
- implement robust cheat name parser and parity helpers
- add server-side cheat state and kill switch handling
- enforce cheat ban during team creation or join
- cover cheat parsing and ban logic with unit and integration tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3c4d255888326b75351a981292808