### PR TITLE
Add cheat parser and kill switch foundations

### DIFF
--- a/src/cheats.py
+++ b/src/cheats.py
@@ -1,0 +1,24 @@
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+CHEAT_RE = re.compile(r'^cheat-(com|hint|tony|kevin)(?:$|[-_\s].*)', re.IGNORECASE)
+
+def parse_cheat_type(team_name: str) -> str:
+    """Return cheat type extracted from team name or 'none'.
+
+    Parsing is case-insensitive and tolerant of suffixes separated by
+    dashes, underscores or whitespace. Any errors are swallowed and
+    treated as no-cheat to avoid disrupting normal play.
+    """
+    try:
+        name = (team_name or "").strip()
+        match = CHEAT_RE.match(name)
+        if not match:
+            return "none"
+        cheat = match.group(1).lower()
+        logger.info("Cheat team detected", extra={"team_name": name, "cheat_type": cheat})
+        return cheat
+    except Exception:
+        return "none"

--- a/src/sockets/team_management.py
+++ b/src/sockets/team_management.py
@@ -4,6 +4,7 @@ from flask_socketio import emit, join_room, leave_room
 from sqlalchemy import func
 from src.config import app, socketio, db
 from src.state import state
+from src.cheats import parse_cheat_type
 from src.models.quiz_models import Teams, PairQuestionRounds, Answers
 from src.game_logic import start_new_round_for_pair
 import logging
@@ -94,6 +95,9 @@ def _reactivate_team_internal(team_name: str, sid: str) -> bool:
                                     .filter_by(team_id=team.team_id).scalar()
         last_played_round_number = max_round_obj if max_round_obj is not None else 0
         
+        # Determine cheat type for this team
+        cheat_type = parse_cheat_type(team_name)
+
         # Set up team state
         state.active_teams[team_name] = {
             'players': [sid],
@@ -102,7 +106,9 @@ def _reactivate_team_internal(team_name: str, sid: str) -> bool:
             'combo_tracker': {},
             'answered_current_round': {},
             'status': 'waiting_pair',
-            'player_slots': {sid: 1}  # Reactivator becomes Player 1
+            'player_slots': {sid: 1},  # Reactivator becomes Player 1
+            'cheat_type': cheat_type,
+            'cached_round_parity': None,
         }
         state.player_to_team[sid] = team_name
         state.team_id_to_name[team.team_id] = team_name
@@ -277,6 +283,12 @@ def on_create_team(data: Dict[str, Any]) -> None:
         if not team_name:
             emit('error', {'message': 'Team name is required'})  # type: ignore
             return
+
+        cheat_type = parse_cheat_type(team_name)
+        if state.cheats_banned and cheat_type != 'none':
+            logger.warning(f"Cheat team creation blocked: {team_name} ({cheat_type})")
+            emit('error', {'message': 'Cheats are disabled'})  # type: ignore
+            return
             
         # Check if team name already exists as active team
         if team_name in state.active_teams or Teams.query.filter_by(team_name=team_name, is_active=True).first():
@@ -286,6 +298,11 @@ def on_create_team(data: Dict[str, Any]) -> None:
         # Check if team name exists as inactive team - if so, reactivate it
         inactive_team = Teams.query.filter_by(team_name=team_name, is_active=False).first()
         if inactive_team:
+            if state.cheats_banned and cheat_type != 'none':
+                logger.warning(f"Cheat team reactivation blocked: {team_name} ({cheat_type})")
+                emit('error', {'message': 'Cheats are disabled'})  # type: ignore
+                return
+
             # Attempt to reactivate the existing inactive team
             if _reactivate_team_internal(team_name, sid):
                 team_info = state.active_teams[team_name]
@@ -330,7 +347,9 @@ def on_create_team(data: Dict[str, Any]) -> None:
             'combo_tracker': {},
             'answered_current_round': {},
             'status': 'waiting_pair',
-            'player_slots': {sid: 1}  # Creator is always Player 1
+            'player_slots': {sid: 1},  # Creator is always Player 1
+            'cheat_type': cheat_type,
+            'cached_round_parity': None,
         }
         state.player_to_team[sid] = team_name
         state.team_id_to_name[new_team_db.team_id] = team_name
@@ -371,6 +390,10 @@ def on_join_team(data: Dict[str, Any]) -> None:
             emit('error', {'message': 'Team not found or invalid team name.'})  # type: ignore
             return
         team_info = state.active_teams[team_name]
+        if state.cheats_banned and team_info.get('cheat_type', 'none') != 'none':
+            logger.warning(f"Cheat team join blocked: {team_name} ({team_info.get('cheat_type')})")
+            emit('error', {'message': 'Cheats are disabled'})  # type: ignore
+            return
         if len(team_info['players']) >= 2:
             emit('error', {'message': 'Team is already full.'})  # type: ignore
             return
@@ -490,6 +513,12 @@ def on_reactivate_team(data: Dict[str, Any]) -> None:
             emit('error', {'message': 'An active team with this name already exists'})  # type: ignore
             return
             
+        cheat_type = parse_cheat_type(team_name)
+        if state.cheats_banned and cheat_type != 'none':
+            logger.warning(f"Cheat team reactivation blocked: {team_name} ({cheat_type})")
+            emit('error', {'message': 'Cheats are disabled'})  # type: ignore
+            return
+
         # Use the internal reactivation helper
         if _reactivate_team_internal(team_name, sid):
             team_info = state.active_teams[team_name]

--- a/src/state.py
+++ b/src/state.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,8 @@ class AppState:
         self.team_id_to_name = {} # {team_id: team_name}
         # Track disconnected players for reconnection - maps team_name to disconnected player info
         self.disconnected_players = {}  # {team_name: {'player_session_id': old_sid, 'player_slot': 1|2, 'disconnect_time': timestamp}}
+        # Moderation kill switch for cheats feature
+        self.cheats_banned = os.getenv('CHEATS_DISABLED', '').lower() == 'true'
 
     @property
     def game_mode(self):

--- a/tests/unit/test_cheats.py
+++ b/tests/unit/test_cheats.py
@@ -1,0 +1,20 @@
+import pytest
+
+from src.cheats import parse_cheat_type
+
+
+@pytest.mark.parametrize(
+    'name,expected',
+    [
+        ('cheat-com', 'com'),
+        ('CHEAT-hint-extra', 'hint'),
+        ('Cheat-Tony', 'tony'),
+        ('cheat-kevin something', 'kevin'),
+        ('cheater', 'none'),
+        ('', 'none'),
+        (None, 'none'),
+        ('cheat-unknown', 'none'),
+    ],
+)
+def test_parse_cheat_type(name, expected):
+    assert parse_cheat_type(name) == expected

--- a/tests/unit/test_team_management.py
+++ b/tests/unit/test_team_management.py
@@ -50,7 +50,9 @@ def active_team():
             'current_round_number': 0,
             'combo_tracker': {},
             'answered_current_round': {},
-            'status': 'waiting_pair'
+            'status': 'waiting_pair',
+            'cheat_type': 'none',
+            'cached_round_parity': None,
         }
         state.player_to_team['player1_sid'] = 'active_team'
         state.team_id_to_name[team.team_id] = 'active_team'
@@ -80,7 +82,9 @@ def full_team():
             'current_round_number': 0,
             'combo_tracker': {},
             'answered_current_round': {},
-            'status': 'active'
+            'status': 'active',
+            'cheat_type': 'none',
+            'cached_round_parity': None,
         }
         state.player_to_team['player1_sid'] = 'full_team'
         state.player_to_team['player2_sid'] = 'full_team'
@@ -100,6 +104,7 @@ def cleanup_state():
     state.connected_players.clear()
     state.dashboard_clients.clear()
     state.disconnected_players.clear()
+    state.cheats_banned = False
 
 def test_reactivate_team_success(mock_request_context, inactive_team):
     """Test successful team reactivation"""
@@ -365,6 +370,73 @@ def test_create_team_reactivation_failure_fallback(mock_request_context, inactiv
             'error',
             {'message': 'An error occurred while reactivating the team'}
         )
+
+
+def test_create_cheat_team_stores_type(mock_request_context):
+    """Cheat team creation stores cheat_type when allowed"""
+    with patch('src.sockets.team_management.emit') as mock_emit, \
+         patch('src.sockets.team_management.socketio.emit') as mock_socketio_emit, \
+         patch('src.sockets.dashboard.emit_dashboard_team_update'), \
+         patch('src.sockets.team_management.join_room'):
+
+        from src.sockets.team_management import on_create_team
+        on_create_team({'team_name': 'cheat-com-team'})
+
+        assert 'cheat-com-team' in state.active_teams
+        assert state.active_teams['cheat-com-team']['cheat_type'] == 'com'
+
+        team = Teams.query.filter_by(team_name='cheat-com-team').first()
+        assert team is not None
+        db.session.delete(team)
+        db.session.commit()
+
+
+def test_create_cheat_team_blocked_when_banned(mock_request_context):
+    """Cheat teams are rejected when cheats are banned"""
+    state.cheats_banned = True
+    with patch('src.sockets.team_management.emit') as mock_emit:
+        from src.sockets.team_management import on_create_team
+        on_create_team({'team_name': 'cheat-hint'})
+        mock_emit.assert_called_once_with('error', {'message': 'Cheats are disabled'})
+        assert 'cheat-hint' not in state.active_teams
+
+
+def test_create_non_cheat_team_allowed_when_banned(mock_request_context):
+    """Non-cheat team creation succeeds even when cheats are banned"""
+    state.cheats_banned = True
+    with patch('src.sockets.team_management.emit') as mock_emit, \
+         patch('src.sockets.team_management.socketio.emit'), \
+         patch('src.sockets.dashboard.emit_dashboard_team_update'), \
+         patch('src.sockets.team_management.join_room'):
+
+        from src.sockets.team_management import on_create_team
+        on_create_team({'team_name': 'fair_team'})
+        assert 'fair_team' in state.active_teams
+        team = Teams.query.filter_by(team_name='fair_team').first()
+        db.session.delete(team)
+        db.session.commit()
+
+
+def test_join_cheat_team_blocked_when_banned(mock_request_context):
+    """Joining existing cheat team is blocked if cheats are banned"""
+    with patch('src.sockets.team_management.emit'), \
+         patch('src.sockets.team_management.socketio.emit'), \
+         patch('src.sockets.dashboard.emit_dashboard_team_update'), \
+         patch('src.sockets.team_management.join_room'):
+        from src.sockets.team_management import on_create_team
+        on_create_team({'team_name': 'cheat-tony'})
+
+    state.cheats_banned = True
+    with patch('src.sockets.team_management.emit') as mock_emit, \
+         patch('src.sockets.team_management.join_room'):
+        from src.sockets.team_management import on_join_team
+        request.sid = 'other_sid'
+        on_join_team({'team_name': 'cheat-tony'})
+        mock_emit.assert_called_once_with('error', {'message': 'Cheats are disabled'})
+
+    team = Teams.query.filter_by(team_name='cheat-tony').first()
+    db.session.delete(team)
+    db.session.commit()
 
 def test_reactivate_team_internal_success(mock_request_context, inactive_team):
     """Test _reactivate_team_internal helper function success"""


### PR DESCRIPTION
## Summary
- add robust `parse_cheat_type` helper
- introduce global `cheats_banned` flag seeded from environment
- enforce cheat ban and store cheat type during team lifecycle
- test cheat parsing and kill switch logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3c4d255888326b75351a981292808