### PR TITLE
feat: add cheats foundation

### DIFF
--- a/src/cheats_utils.py
+++ b/src/cheats_utils.py
@@ -1,0 +1,53 @@
+import re
+from typing import Optional, Tuple
+from src.models.quiz_models import ItemEnum
+
+CHEAT_RE = re.compile(r'^cheat-(com|hint|tony|kevin)(?:$|[^a-zA-Z].*)', re.IGNORECASE)
+
+def parse_cheat_type(team_name: Optional[str]) -> str:
+    """Parse team name for cheat prefix.
+
+    Returns one of 'none', 'com', 'hint', 'tony', 'kevin'.
+    Any parsing error results in 'none'.
+    """
+    try:
+        name = (team_name or "").strip()
+        m = CHEAT_RE.match(name)
+        if not m:
+            return "none"
+        return m.group(1).lower()
+    except Exception:
+        return "none"
+
+def get_required_parity(p1_item: ItemEnum, p2_item: ItemEnum) -> str:
+    """Determine required parity for a pair of items.
+
+    BY or YB => 'different', otherwise 'same'.
+    """
+    if ((p1_item == ItemEnum.B and p2_item == ItemEnum.Y) or
+            (p1_item == ItemEnum.Y and p2_item == ItemEnum.B)):
+        return "different"
+    return "same"
+
+def recommend_answers(
+    p1_item: ItemEnum,
+    p2_item: ItemEnum,
+    p1_answer: Optional[bool] = None,
+    p2_answer: Optional[bool] = None,
+) -> Tuple[bool, bool]:
+    """Recommend answers based on required parity and known responses."""
+    parity = get_required_parity(p1_item, p2_item)
+    if p1_answer is None and p2_answer is None:
+        if parity == "same":
+            return True, True
+        return True, False
+    if p1_answer is not None and p2_answer is None:
+        if parity == "same":
+            return p1_answer, p1_answer
+        return p1_answer, not p1_answer
+    if p2_answer is not None and p1_answer is None:
+        if parity == "same":
+            return p2_answer, p2_answer
+        return not p2_answer, p2_answer
+    # If both answers known, simply return them
+    return bool(p1_answer), bool(p2_answer)

--- a/src/sockets/team_management.py
+++ b/src/sockets/team_management.py
@@ -6,6 +6,7 @@ from src.config import app, socketio, db
 from src.state import state
 from src.models.quiz_models import Teams, PairQuestionRounds, Answers
 from src.game_logic import start_new_round_for_pair
+from src.cheats_utils import parse_cheat_type
 import logging
 import time
 from typing import Dict, Any, List, Optional
@@ -102,7 +103,9 @@ def _reactivate_team_internal(team_name: str, sid: str) -> bool:
             'combo_tracker': {},
             'answered_current_round': {},
             'status': 'waiting_pair',
-            'player_slots': {sid: 1}  # Reactivator becomes Player 1
+            'player_slots': {sid: 1},  # Reactivator becomes Player 1
+            'cheat_type': parse_cheat_type(team_name),
+            'cached_round_parity': None,
         }
         state.player_to_team[sid] = team_name
         state.team_id_to_name[team.team_id] = team_name
@@ -274,6 +277,11 @@ def on_create_team(data: Dict[str, Any]) -> None:
     try:
         team_name = data.get('team_name')
         sid = request.sid  # type: ignore
+        cheat_type = parse_cheat_type(team_name)
+        logger.info(f"Parsed cheat type '{cheat_type}' for team '{team_name}'")
+        if state.cheats_banned and cheat_type != 'none':
+            emit('error', {'message': 'Cheats are disabled for this game.'})  # type: ignore
+            return
         if not team_name:
             emit('error', {'message': 'Team name is required'})  # type: ignore
             return
@@ -330,7 +338,9 @@ def on_create_team(data: Dict[str, Any]) -> None:
             'combo_tracker': {},
             'answered_current_round': {},
             'status': 'waiting_pair',
-            'player_slots': {sid: 1}  # Creator is always Player 1
+            'player_slots': {sid: 1},  # Creator is always Player 1
+            'cheat_type': cheat_type,
+            'cached_round_parity': None,
         }
         state.player_to_team[sid] = team_name
         state.team_id_to_name[new_team_db.team_id] = team_name
@@ -371,6 +381,11 @@ def on_join_team(data: Dict[str, Any]) -> None:
             emit('error', {'message': 'Team not found or invalid team name.'})  # type: ignore
             return
         team_info = state.active_teams[team_name]
+        cheat_type = team_info.get('cheat_type', 'none')
+        logger.info(f"Join request for team '{team_name}' with cheat type '{cheat_type}'")
+        if state.cheats_banned and cheat_type != 'none':
+            emit('error', {'message': 'Cheats are disabled for this game.'})  # type: ignore
+            return
         if len(team_info['players']) >= 2:
             emit('error', {'message': 'Team is already full.'})  # type: ignore
             return
@@ -474,7 +489,12 @@ def on_reactivate_team(data: Dict[str, Any]) -> None:
     try:
         team_name = data.get('team_name')
         sid = request.sid  # type: ignore
-        
+        cheat_type = parse_cheat_type(team_name)
+        logger.info(f"Reactivation request for team '{team_name}' with cheat type '{cheat_type}'")
+        if state.cheats_banned and cheat_type != 'none':
+            emit('error', {'message': 'Cheats are disabled for this game.'})  # type: ignore
+            return
+
         if not team_name:
             emit('error', {'message': 'Team name is required'})  # type: ignore
             return

--- a/src/state.py
+++ b/src/state.py
@@ -1,17 +1,19 @@
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
 
 class AppState:
     def __init__(self):
-        self.active_teams = {}  # {team_name: {'players': [], 'team_id': db_team_id, 'current_round_number': 0, 'combo_tracker': {}, 'current_db_round_id': None, 'answered_current_round': {}, 'player_slots': {sid: slot_number}}}
+        self.active_teams = {}  # {team_name: {'players': [], 'team_id': db_team_id, 'current_round_number': 0, 'combo_tracker': {}, 'current_db_round_id': None, 'answered_current_round': {}, 'player_slots': {sid: slot_number}, 'cheat_type': 'none', 'cached_round_parity': None}}
         self.player_to_team = {}  # {sid: team_name}
         self.connected_players = set()  # All connected player SIDs
         self.dashboard_clients = set() # Stores SIDs of connected dashboard clients
         self.game_started = False # Track if game has started
         self.game_paused = False # Track if game is paused
         self.answer_stream_enabled = False # Track if answer streaming is enabled
+        self.cheats_banned = os.getenv('CHEATS_DISABLED', 'false').lower() == 'true'
         # Internal storage for game mode with normalization
         self._game_mode = 'simplified'  # Track current game mode: 'classic', 'simplified', or 'aqmjoe'
         self.game_theme = 'food'  # Track current game theme: 'classic', 'food', etc.
@@ -48,6 +50,7 @@ class AppState:
         self.answer_stream_enabled = False
         self.game_mode = 'simplified'  # Reset game mode to simplified
         self.game_theme = 'food'  # Reset game theme to food
+        self.cheats_banned = os.getenv('CHEATS_DISABLED', 'false').lower() == 'true'
 
     def get_player_slot(self, team_name, sid):
         """Get the database player slot (1 or 2) for a session ID in a team"""

--- a/tests/unit/test_cheats_management.py
+++ b/tests/unit/test_cheats_management.py
@@ -1,0 +1,57 @@
+import pytest
+from unittest.mock import patch, ANY
+from flask import request
+from src.config import app, socketio, db
+from src.state import state
+
+
+@pytest.fixture
+def app_context():
+    with app.app_context():
+        app.extensions['socketio'] = socketio
+        db.drop_all()
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def mock_request_context(app_context):
+    ctx = app_context.test_request_context('/')
+    ctx.push()
+    request.sid = 'sid1'
+    request.namespace = '/'
+    yield request
+    ctx.pop()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_state():
+    state.reset()
+    yield
+    state.reset()
+
+
+def test_create_cheat_team_stores_type(mock_request_context):
+    from src.sockets.team_management import on_create_team
+    with patch('src.sockets.team_management.emit') as mock_emit, \
+         patch('src.sockets.team_management.socketio.emit'), \
+         patch('src.sockets.team_management.join_room'):
+        on_create_team({'team_name': 'cheat-com-foo'})
+        assert state.active_teams['cheat-com-foo']['cheat_type'] == 'com'
+        mock_emit.assert_any_call('team_created', ANY)
+
+
+def test_create_cheat_team_rejected_when_banned(mock_request_context):
+    from src.sockets.team_management import on_create_team
+    state.cheats_banned = True
+    with patch('src.sockets.team_management.emit') as mock_emit, \
+         patch('src.sockets.team_management.join_room'):
+        on_create_team({'team_name': 'cheat-hint-bar'})
+        assert 'cheat-hint-bar' not in state.active_teams
+        args, kwargs = mock_emit.call_args
+        assert args[0] == 'error'
+        assert 'Cheats' in args[1]['message']
+
+

--- a/tests/unit/test_cheats_utils.py
+++ b/tests/unit/test_cheats_utils.py
@@ -1,0 +1,32 @@
+import pytest
+from src.cheats_utils import parse_cheat_type, get_required_parity, recommend_answers
+from src.models.quiz_models import ItemEnum
+
+
+def test_parse_cheat_type_cases():
+    assert parse_cheat_type("cheat-com") == "com"
+    assert parse_cheat_type("CheAt-CoM-foo") == "com"
+    assert parse_cheat_type("cheat-hint bar") == "hint"
+    assert parse_cheat_type("cheat-tony_baz") == "tony"
+    assert parse_cheat_type("cheat-kevin123") == "kevin"
+    assert parse_cheat_type("cheat-unknown") == "none"
+    assert parse_cheat_type("honest") == "none"
+    assert parse_cheat_type("") == "none"
+    assert parse_cheat_type(None) == "none"
+
+
+def test_get_required_parity():
+    assert get_required_parity(ItemEnum.B, ItemEnum.Y) == "different"
+    assert get_required_parity(ItemEnum.A, ItemEnum.Y) == "same"
+    assert get_required_parity(ItemEnum.B, ItemEnum.X) == "same"
+
+
+def test_recommend_answers():
+    # Both answers unknown
+    assert recommend_answers(ItemEnum.A, ItemEnum.X) == (True, True)
+    # One answer known, same parity
+    assert recommend_answers(ItemEnum.A, ItemEnum.X, p1_answer=False) == (False, False)
+    # One answer known, different parity
+    assert recommend_answers(ItemEnum.B, ItemEnum.Y, p1_answer=True) == (True, False)
+    # Known second answer
+    assert recommend_answers(ItemEnum.B, ItemEnum.Y, p2_answer=True) == (False, True)


### PR DESCRIPTION
## Summary
- introduce cheat utilities with parser and helper logic
- track cheat state in global app state and team data
- gate team creation/join/reactivation when cheats are banned and add tests

## Testing
- `pytest tests/unit/test_cheats_utils.py tests/unit/test_cheats_management.py -q`
- `pytest -q` *(fails: Error testing download endpoint: Download endpoint returned error: 500)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c4d255888326b75351a981292808