### PR TITLE
feat: add cheat mode scaffolding

### DIFF
--- a/src/cheats_utils.py
+++ b/src/cheats_utils.py
@@ -1,0 +1,24 @@
+import logging
+import re
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+CHEAT_RE = re.compile(r'^cheat-(com|hint|tony|kevin)(?:$|[-_\s].*)', re.IGNORECASE)
+
+def parse_cheat_type(team_name: str) -> Literal['none','com','hint','tony','kevin']:
+    """Parse the cheat type from a team name.
+
+    Returns one of 'com', 'hint', 'tony', 'kevin', or 'none' if no cheat prefix is detected.
+    Parsing is case-insensitive and tolerant of suffixes after the cheat type.
+    Any errors result in a safe default of 'none'.
+    """
+    try:
+        name = (team_name or '').strip()
+        m = CHEAT_RE.match(name)
+        if not m:
+            return 'none'
+        return m.group(1).lower()
+    except Exception as e:
+        logger.warning(f"Failed to parse cheat type from {team_name!r}: {e}")
+        return 'none'

--- a/src/sockets/team_management.py
+++ b/src/sockets/team_management.py
@@ -5,6 +5,7 @@ from sqlalchemy import func
 from src.config import app, socketio, db
 from src.state import state
 from src.models.quiz_models import Teams, PairQuestionRounds, Answers
+from src.cheats_utils import parse_cheat_type
 from src.game_logic import start_new_round_for_pair
 import logging
 import time
@@ -72,6 +73,11 @@ def _reactivate_team_internal(team_name: str, sid: str) -> bool:
     Returns True if successful, False otherwise.
     """
     try:
+        cheat_type = parse_cheat_type(team_name)
+        if state.cheats_banned and cheat_type != 'none':
+            logger.warning(f"Cheat team {team_name} blocked from reactivation")
+            return False
+
         # Find the inactive team in the database
         team = Teams.query.filter_by(team_name=team_name, is_active=False).first()
         if not team:
@@ -102,8 +108,12 @@ def _reactivate_team_internal(team_name: str, sid: str) -> bool:
             'combo_tracker': {},
             'answered_current_round': {},
             'status': 'waiting_pair',
-            'player_slots': {sid: 1}  # Reactivator becomes Player 1
+            'player_slots': {sid: 1},  # Reactivator becomes Player 1
+            'cheat_type': cheat_type,
+            'cached_round_parity': None,
         }
+        if cheat_type != 'none':
+            logger.info(f"Team {team_name} reactivated with cheat type {cheat_type}")
         state.player_to_team[sid] = team_name
         state.team_id_to_name[team.team_id] = team_name
         
@@ -277,10 +287,17 @@ def on_create_team(data: Dict[str, Any]) -> None:
         if not team_name:
             emit('error', {'message': 'Team name is required'})  # type: ignore
             return
-            
+
         # Check if team name already exists as active team
         if team_name in state.active_teams or Teams.query.filter_by(team_name=team_name, is_active=True).first():
             emit('error', {'message': 'Team name already exists or is active'})  # type: ignore
+            return
+
+        cheat_type = parse_cheat_type(team_name)
+        if cheat_type != 'none':
+            logger.info(f"Team {team_name} detected with cheat type {cheat_type}")
+        if state.cheats_banned and cheat_type != 'none':
+            emit('error', {'message': 'Cheats are disabled'})  # type: ignore
             return
 
         # Check if team name exists as inactive team - if so, reactivate it
@@ -330,7 +347,9 @@ def on_create_team(data: Dict[str, Any]) -> None:
             'combo_tracker': {},
             'answered_current_round': {},
             'status': 'waiting_pair',
-            'player_slots': {sid: 1}  # Creator is always Player 1
+            'player_slots': {sid: 1},  # Creator is always Player 1
+            'cheat_type': cheat_type,
+            'cached_round_parity': None,
         }
         state.player_to_team[sid] = team_name
         state.team_id_to_name[new_team_db.team_id] = team_name
@@ -371,6 +390,12 @@ def on_join_team(data: Dict[str, Any]) -> None:
             emit('error', {'message': 'Team not found or invalid team name.'})  # type: ignore
             return
         team_info = state.active_teams[team_name]
+        cheat_type = team_info.get('cheat_type', 'none')
+        if cheat_type != 'none':
+            logger.info(f"Player {sid} joining cheat team {team_name} ({cheat_type})")
+        if state.cheats_banned and cheat_type != 'none':
+            emit('error', {'message': 'Cheats are disabled'})  # type: ignore
+            return
         if len(team_info['players']) >= 2:
             emit('error', {'message': 'Team is already full.'})  # type: ignore
             return
@@ -474,11 +499,18 @@ def on_reactivate_team(data: Dict[str, Any]) -> None:
     try:
         team_name = data.get('team_name')
         sid = request.sid  # type: ignore
-        
+
         if not team_name:
             emit('error', {'message': 'Team name is required'})  # type: ignore
             return
-            
+
+        cheat_type = parse_cheat_type(team_name)
+        if cheat_type != 'none':
+            logger.info(f"Team {team_name} attempting reactivation with cheat type {cheat_type}")
+        if state.cheats_banned and cheat_type != 'none':
+            emit('error', {'message': 'Cheats are disabled'})  # type: ignore
+            return
+
         # Check if team exists as inactive
         inactive_team = Teams.query.filter_by(team_name=team_name, is_active=False).first()
         if not inactive_team:

--- a/src/state.py
+++ b/src/state.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,8 @@ class AppState:
         self.team_id_to_name = {} # {team_id: team_name}
         # Track disconnected players for reconnection - maps team_name to disconnected player info
         self.disconnected_players = {}  # {team_name: {'player_session_id': old_sid, 'player_slot': 1|2, 'disconnect_time': timestamp}}
+        # Global cheat control flag with optional env kill switch
+        self.cheats_banned = os.getenv('CHEATS_DISABLED', 'false').lower() == 'true'
 
     @property
     def game_mode(self):
@@ -48,6 +51,7 @@ class AppState:
         self.answer_stream_enabled = False
         self.game_mode = 'simplified'  # Reset game mode to simplified
         self.game_theme = 'food'  # Reset game theme to food
+        self.cheats_banned = os.getenv('CHEATS_DISABLED', 'false').lower() == 'true'
 
     def get_player_slot(self, team_name, sid):
         """Get the database player slot (1 or 2) for a session ID in a team"""

--- a/tests/integration/test_cheats_foundations.py
+++ b/tests/integration/test_cheats_foundations.py
@@ -1,0 +1,31 @@
+import eventlet
+eventlet.monkey_patch()
+
+from flask_socketio import SocketIOTestClient
+from src.config import app, socketio as server_socketio
+from src.state import state
+from src.models.quiz_models import Teams, PairQuestionRounds, Answers, db
+
+
+def reset_state():
+    with app.app_context():
+        Answers.query.delete()
+        PairQuestionRounds.query.delete()
+        Teams.query.delete()
+        db.session.commit()
+    state.reset()
+
+
+def test_non_cheat_team_receives_no_cheat_events():
+    reset_state()
+    client1 = SocketIOTestClient(app, server_socketio)
+    client2 = SocketIOTestClient(app, server_socketio)
+
+    client1.emit('create_team', {'team_name': 'honest'})
+    client2.emit('join_team', {'team_name': 'honest'})
+
+    for event in client1.get_received() + client2.get_received():
+        assert not event['name'].startswith('cheat')
+
+    client1.disconnect()
+    client2.disconnect()

--- a/tests/unit/test_cheats_utils.py
+++ b/tests/unit/test_cheats_utils.py
@@ -1,0 +1,20 @@
+import pytest
+from src.cheats_utils import parse_cheat_type
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("cheat-com", "com"),
+        ("cheat-COM-extra", "com"),
+        ("cheat-hint foo", "hint"),
+        ("cheat-tony_bar", "tony"),
+        ("  cheat-kevin  ", "kevin"),
+        ("CHEAT-KEVIN-BONUS", "kevin"),
+        ("cheat-unknown", "none"),
+        ("some team", "none"),
+        ("", "none"),
+        (None, "none"),
+    ],
+)
+def test_parse_cheat_type(name, expected):
+    assert parse_cheat_type(name) == expected

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -23,6 +23,7 @@ def test_app_state_initialization():
     
     assert isinstance(state.team_id_to_name, dict)
     assert len(state.team_id_to_name) == 0
+    assert state.cheats_banned is False
 
 def test_app_state_reset():
     """Test that AppState.reset() properly clears all state"""
@@ -37,6 +38,7 @@ def test_app_state_reset():
     state.connected_players = {"player1", "player2"}
     state.game_paused = True
     state.team_id_to_name = {1: "team1"}
+    state.cheats_banned = True
     
     # Reset state
     state.reset()
@@ -50,6 +52,7 @@ def test_app_state_reset():
     assert len(state.connected_players) == 0
     assert state.game_paused is False
     assert len(state.team_id_to_name) == 0
+    assert state.cheats_banned is False
 
 def test_app_state_team_tracking():
     """Test adding and removing teams from state"""

--- a/tests/unit/test_team_management.py
+++ b/tests/unit/test_team_management.py
@@ -100,6 +100,15 @@ def cleanup_state():
     state.connected_players.clear()
     state.dashboard_clients.clear()
     state.disconnected_players.clear()
+    state.cheats_banned = False
+
+def test_create_cheat_team_when_banned(mock_request_context):
+    """Creating a cheat team should be blocked when cheats are banned"""
+    state.cheats_banned = True
+    with patch('src.sockets.team_management.emit') as mock_emit:
+        from src.sockets.team_management import on_create_team
+        on_create_team({'team_name': 'cheat-com-foo'})
+        mock_emit.assert_called_once_with('error', {'message': 'Cheats are disabled'})
 
 def test_reactivate_team_success(mock_request_context, inactive_team):
     """Test successful team reactivation"""


### PR DESCRIPTION
## Summary
- add robust cheat prefix parser and global cheat kill switch
- log and store cheat type for teams; block cheat joins when disabled
- cover cheat utilities and ban guardrails with unit and integration tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3c4d255888326b75351a981292808