### PR TITLE
[codex] Fix dashboard success-rate mode handling

### DIFF
--- a/.ai/memory/maestri-portal-usage.md
+++ b/.ai/memory/maestri-portal-usage.md
@@ -1,0 +1,73 @@
+# Maestri Portal Usage — CHSH Game Testing
+
+## Setup
+
+Three portals are pre-configured on the Maestri canvas:
+- `Game-Dashboard` → `http://localhost:8080/dashboard` (Host Dashboard, 1000×929)
+- `Game-L` → `http://localhost:8080/` (Player 1, 500×929)
+- `Game-R` → `http://localhost:8080/` (Player 2, 500×929)
+
+Always verify with `maestri list` before starting. Server must be running (`gunicorn wsgi:app --worker-class eventlet --bind 0.0.0.0:8080`).
+
+## Key CLI Commands
+
+```bash
+maestri list                              # verify portals/agents connected
+maestri portal info "Game-Dashboard"      # get URL, title, viewport
+maestri portal screenshot "Portal"        # capture PNG → read with Read tool
+maestri portal snapshot "Portal"          # accessibility tree with refs (@e1, @e2...)
+maestri portal click "Portal" @e1         # click by ref (preferred)
+maestri portal click "Portal" "x,y"       # click by coordinates (fallback)
+maestri portal fill "Portal" @e1 "text"   # clear input and set value
+maestri portal evaluate "Portal" "js"     # JS fallback if click by ref fails
+```
+
+## Running a Full Game Test
+
+```bash
+# 1. Game-L creates a team
+maestri portal snapshot "Game-L"          # find @e1=input, @e2=Create Team
+maestri portal fill "Game-L" @e1 "TeamName"
+maestri portal click "Game-L" @e2
+
+# 2. Game-R joins the team (Join Team button appears once a team exists)
+maestri portal snapshot "Game-R"          # find @e3=Join Team
+maestri portal click "Game-R" @e3
+
+# 3. Start game from dashboard
+maestri portal evaluate "Game-Dashboard" "document.querySelector('button').click(); 'clicked'"
+# Note: direct click by ref often fails for the Start Game button; JS eval is reliable
+
+# 4. Each round — check ingredients, then answer
+maestri portal screenshot "Game-L"        # see Player 1's ingredient
+maestri portal screenshot "Game-R"        # see Player 2's ingredient
+maestri portal click "Game-L" @e1        # CHOOSE
+maestri portal click "Game-R" @e2        # SKIP
+# Run both in parallel with: cmd & cmd & wait
+```
+
+## CHSH Ingredient Mapping (Simplified Mode)
+
+Player 1 (Game-L) gets A/B ingredients; Player 2 (Game-R) gets X/Y ingredients.
+
+| Ingredient | Role |
+|------------|------|
+| Bread      | A (Player 1) |
+| Dumplings  | B (Player 1) |
+| Lettuce    | X (Player 2) |
+| Chocolate  | Y (Player 2) |
+
+**Winning rule:** same answer wins *except* Dumplings(B) + Chocolate(Y) where different answers win.
+
+| P1 \ P2    | Lettuce(X) | Chocolate(Y) |
+|------------|------------|--------------|
+| Bread(A)   | same ✓     | same ✓       |
+| Dumplings(B) | same ✓   | different ✓  |
+
+## Gotchas
+
+- `click` by ref (`@eN`) can fail if the DOM changed since `snapshot`; re-run `snapshot` to refresh refs.
+- The Start Game button ref click consistently fails — use `evaluate` with `document.querySelector('button').click()` instead.
+- Parallelise independent clicks with `cmd & cmd & wait` to simulate simultaneous answers.
+- After clicking, `sleep 1` before the next screenshot to let the server respond.
+- Stats Sig shows an hourglass until enough rounds are played for significance.

--- a/.ai/memory/maestri-portal-usage.md
+++ b/.ai/memory/maestri-portal-usage.md
@@ -24,27 +24,30 @@ maestri portal evaluate "Portal" "js"     # JS fallback if click by ref fails
 
 ## Running a Full Game Test
 
+Use stable `evaluate` + `getElementById` for all critical actions (immune to positional ref shifts):
+
 ```bash
 # 1. Game-L creates a team
-maestri portal snapshot "Game-L"          # find @e1=input, @e2=Create Team
-maestri portal fill "Game-L" @e1 "TeamName"
-maestri portal click "Game-L" @e2
+maestri portal evaluate "Game-L" "document.getElementById('teamNameInput').value = 'TeamName'; 'ok'"
+maestri portal evaluate "Game-L" "document.getElementById('createTeamBtn').click(); 'ok'"
 
-# 2. Game-R joins the team (Join Team button appears once a team exists)
-maestri portal snapshot "Game-R"          # find @e3=Join Team
-maestri portal click "Game-R" @e3
+# 2. Game-R joins the team (join button appears after team list updates)
+# Use data-team-name attribute — exact team name, no transform, collision-free
+maestri portal evaluate "Game-R" "document.querySelector('.join-btn[data-team-name=\"TeamName\"]').click(); 'ok'"
 
 # 3. Start game from dashboard
-maestri portal evaluate "Game-Dashboard" "document.querySelector('button').click(); 'clicked'"
-# Note: direct click by ref often fails for the Start Game button; JS eval is reliable
+maestri portal evaluate "Game-Dashboard" "document.getElementById('start-game-btn').click(); 'ok'"
 
 # 4. Each round — check ingredients, then answer
 maestri portal screenshot "Game-L"        # see Player 1's ingredient
 maestri portal screenshot "Game-R"        # see Player 2's ingredient
-maestri portal click "Game-L" @e1        # CHOOSE
-maestri portal click "Game-R" @e2        # SKIP
-# Run both in parallel with: cmd & cmd & wait
+maestri portal evaluate "Game-L" "document.getElementById('trueBtn').click(); 'ok'" &
+maestri portal evaluate "Game-R" "document.getElementById('falseBtn').click(); 'ok'" &
+wait
+# trueBtn = Choose/True, falseBtn = Skip/False (text varies by theme, IDs are stable)
 ```
+
+If you do use `snapshot` for exploration, key interactive controls now have `aria-label` attributes, so refs are more human-readable (e.g. `@e3 [button] "Start game"`).
 
 ## CHSH Ingredient Mapping (Simplified Mode)
 
@@ -66,8 +69,8 @@ Player 1 (Game-L) gets A/B ingredients; Player 2 (Game-R) gets X/Y ingredients.
 
 ## Gotchas
 
-- `click` by ref (`@eN`) can fail if the DOM changed since `snapshot`; re-run `snapshot` to refresh refs.
-- The Start Game button ref click consistently fails — use `evaluate` with `document.querySelector('button').click()` instead.
+- `click` by ref (`@eN`) can fail if the DOM changed since `snapshot`; prefer `evaluate` + `getElementById` for reliability.
 - Parallelise independent clicks with `cmd & cmd & wait` to simulate simultaneous answers.
 - After clicking, `sleep 1` before the next screenshot to let the server respond.
+- Dynamic join/reactivate buttons are targeted via `data-team-name` attribute (exact team name, no transform): `querySelector('.join-btn[data-team-name="My Team"]')`.
 - Stats Sig shows an hourglass until enough rounds are played for significance.

--- a/.ai/memory/pytest_notes.md
+++ b/.ai/memory/pytest_notes.md
@@ -1,0 +1,22 @@
+# Pytest Notes
+
+## Port 8080 must be free before running pytest
+
+The conftest starts its own gunicorn server on port 8080 for integration tests. If a stale process (dev server or previous test run) already holds the port, gunicorn exits immediately and all tests error out.
+
+Before running pytest:
+```bash
+kill $(lsof -ti :8080) 2>/dev/null
+```
+
+Watch for zombie gunicorn master processes that survive Ctrl+C — they hold the port even after workers exit. Verify with `lsof -i :8080 | grep LISTEN`.
+
+## Missing dev dependencies (load_test module)
+
+The `load_test/` module and its tests require packages not in the core `requirements.txt`. These are now tracked in `requirements-dev.txt` (or via `-r load_test/load_test_requirements.txt`). If new `ModuleNotFoundError`s appear during collection, add the missing package to `requirements-dev.txt`.
+
+## eventlet monkey patching and tests
+
+`src/config.py` guards `eventlet.monkey_patch()` behind the `TESTING` env flag. The conftest sets `TESTING=1` at module level so it takes effect before any `src` imports during collection. Test files must **not** call `eventlet.monkey_patch()` at module level — doing so patches `subprocess` and `socket` in the pytest process, causing `requests`-based tests to hang and `subprocess.Popen` to break.
+
+`SocketIOTestClient` tests use `async_mode='threading'` (set automatically when `TESTING=1`) — no eventlet hub needed. Use `time.sleep` instead of `eventlet.sleep` in test files.

--- a/.ai/project-instructions.md
+++ b/.ai/project-instructions.md
@@ -76,7 +76,7 @@ Backend stack: Flask + Flask-SocketIO + Eventlet + SQLAlchemy.
 
 ## Key Behaviour
 
-- Supported modes: `simplified` (default), `classic`, `aqmjoe`.
+- Supported modes: `aqmjoe` (default), `simplified`, `classic`.
 - Legacy mode value `'new'` is normalized to `'simplified'`.
 - In `simplified` mode, player 1 gets A/B items and player 2 gets X/Y items; other modes allow all combinations.
 - Some dashboard functions are imported inside function bodies in `src/sockets/game.py` to avoid circular imports.

--- a/.ai/project-instructions.md
+++ b/.ai/project-instructions.md
@@ -79,6 +79,11 @@ Backend stack: Flask + Flask-SocketIO + Eventlet + SQLAlchemy.
 - Supported modes: `aqmjoe` (default), `simplified`, `classic`.
 - Legacy mode value `'new'` is normalized to `'simplified'`.
 - In `simplified` mode, player 1 gets A/B items and player 2 gets X/Y items; other modes allow all combinations.
+- In `classic` mode, the dashboard's main statistics are CHSH/correlation metrics. In `simplified` and `aqmjoe`, the main statistics are success-rate metrics.
+- `Stats Sig` is a combo-coverage eligibility gate for dashboard awards, not just a high round count. `simplified` requires the four ordered A/B x X/Y pairs with doubled repeats; `aqmjoe` and `classic` require all 16 ordered A/B/X/Y pairs.
+- AQM Joe is the default mode. A short demo, such as 30 rounds, may still be ineligible for the trophy because AQM Joe samples all 16 ordered item pairs.
+- Teams progress independently. Different teams can intentionally be on different round numbers.
+- `Connected Players` currently counts all connected Socket.IO clients recorded in `state.connected_players`, including dashboard socket clients.
 - Some dashboard functions are imported inside function bodies in `src/sockets/game.py` to avoid circular imports.
 - CHSH calculations use the `uncertainties` package (`ufloat`) for error propagation.
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,3 @@ downloaded_test.csv
 src/static/sub/hello.txt
 .idea
 coverage.xml
-
-# AI workspace — memory is machine-local
-.ai/memory/*
-!.ai/memory/.gitkeep

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Teams of two players answer random A/B/X/Y questions while a host dashboard trac
 
 
 ### New! v2
-The game now supports three modes:
+The game defaults to **AQM Joe Mode** and supports three modes:
 - **Classic Mode** Standard CHSH Bell Test game in the style of how physics experiments are done.
 - **Simplified Mode** Implementation of the CHSH game where player 1 only need to answer A/B questions, and player 2 only need to answer X/Y questions. 
 - **AQM Joe Mode** Each player is asked about their favourite color or food.
@@ -59,15 +59,19 @@ TODO
     - ***No communication*** is allowed during the game! 
 
 **Winning condition:**
-- Highest **balanced ⏐⟨Tr⟩⏐ 🎯** (consistency):
-  - If both players are asked the same question (A/A, B/B, X/X, or Y/Y), they should give the **same** answer. 
-    - Trace/4 = ⟨Tr⟩ = ±1 if partners always agree, and 0 if players always disagrees.
-    - Balance = 1 if answers to each question is True/False about 50:50 of the time, and 0 if always the same.
+- In **Classic Mode**, the dashboard awards CHSH/correlation trophies:
+    - Highest **balanced ⏐⟨Tr⟩⏐ 🎯** (consistency): if both players are asked the same question (A/A, B/B, X/X, or Y/Y), they should give the **same** answer.
+    - Trace/4 = ⟨Tr⟩ = ±1 if partners always agree, and 0 if players always disagree.
+    - Balance = 1 if answers to each question are True/False about 50:50 of the time, and 0 if always the same.
     - Balanced |⟨Tr⟩| = 0.5 * (balance + |⟨Tr⟩|); higher is better.
-- Best **CHSH 🏆** (non-local correlation):
-  - If one player is asked **B** and the other is asked **Y**, they have to answer **differently** as much as possible, i.e. one True and one False.
-  - For any other question pair, you have to give same response as much as possible.
-  </details>
+    - Best **CHSH 🏆** (non-local correlation): if one player is asked **B** and the other is asked **Y**, they should answer **differently** as much as possible; for any other question pair, they should give the same response as much as possible.
+- In **Simplified Mode** and **AQM Joe Mode**, the dashboard awards the success-rate **🏆** after Stats Sig eligibility is reached. Stats Sig means the required question-pair coverage has been reached, not merely that many rounds have been played.
+- In **AQM Joe Mode**, all 16 ordered item pairs are sampled, so a 30-round demo may still show the hourglass and no trophy before full Stats Sig eligibility.
+</details>
+
+Dashboard notes:
+- Teams progress independently; different teams can be on different round numbers.
+- The **Connected Players** count includes dashboard socket clients as well as player clients.
 
 <details>
 <summary>Winning Strategy (click to unfold)</summary>
@@ -229,4 +233,3 @@ The `chsh_load_test.py` script simulates many teams and players. See [`LOAD_TEST
 
 ## Acknowledgements
 - More than 99% of the code are AI generated, thanks to GitHub Copilot, OpenAI Codex, Cursor, Manus, DeepSeek, Claude Code, Qwen and more. Probably, billions of tokens have burned up in vibe coding this app. 
-

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ TODO
 - Best **CHSH 🏆** (non-local correlation):
   - If one player is asked **B** and the other is asked **Y**, they have to answer **differently** as much as possible, i.e. one True and one False.
   - For any other question pair, you have to give same response as much as possible.
-</details>
+  </details>
 
 <details>
 <summary>Winning Strategy (click to unfold)</summary>
@@ -165,7 +165,7 @@ $$
 \vert p \rangle = \frac{1}{\sqrt{2}} \big( \vert g \rangle + \vert r \rangle \big) 
 \text{ and }
 \vert c \rangle = \frac{1}{\sqrt{2}} \big( \vert g \rangle - \vert r \rangle \big)
-$$ 
+$$
 
 
 
@@ -228,6 +228,5 @@ The `chsh_load_test.py` script simulates many teams and players. See [`LOAD_TEST
 
 
 ## Acknowledgements
-- More than 99% of the code are AI generated, thanks to GitHub Copilot, ChatGPT, Cursor, Manus, DeepSeek, Antropic, Qwen and more. Probably, more than few billion tokens got burned up in generating this app. 
-
+- More than 99% of the code are AI generated, thanks to GitHub Copilot, OpenAI Codex, Cursor, Manus, DeepSeek, Claude Code, Qwen and more. Probably, billions of tokens have burned up in vibe coding this app. 
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,29 @@ gunicorn wsgi:app --worker-class eventlet --bind 0.0.0.0:8080
 Visit [http://localhost:8080/](http://localhost:8080/) for the player view, and [http://localhost:8080/dashboard](http://localhost:8080/dashboard) for the dashboard.
 Feel free to change the port number `8080` in the command above.
 
+**Deploying to Fly.io:**
+
+Prerequisites: install the [Fly CLI](https://fly.io/docs/getting-started/installing-flyctl/).
+
+Login to Fly (first time only):
+```bash
+fly auth login
+```
+
+Deploy from the repo root:
+```bash
+fly deploy
+```
+
+Check deployment status:
+```bash
+fly status
+fly logs          # View live logs
+fly open          # Open the app in your browser
+```
+
+The `fly.toml` is configured to scale to zero after 1 hour of inactivity. For always-on hosting, set `min_machines_running = 1` in `fly.toml`.
+
 **Deploying to Render.com:**  
 Start command:  
 ```bash

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,11 @@
-# Testing
-pytest==8.3.3
+# Shared load-test and CLI tooling dependencies
+-r load_test/load_test_requirements.txt
+
+# Project test helpers
 pytest-cov==6.1.1
 pytest-mock==3.14.0
 requests==2.32.4
 beautifulsoup4==4.12.3
 
 # Development Tools
-mypy==1.16.1
 pyright==1.1.402 

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,9 @@
 import os
-import eventlet
-eventlet.monkey_patch()
+
+_testing = os.environ.get('TESTING', '').lower() not in ('', '0', 'false', 'no')
+if not _testing:
+    import eventlet
+    eventlet.monkey_patch()
 
 from flask import Flask
 from flask_socketio import SocketIO
@@ -18,7 +21,9 @@ app.config['SQLALCHEMY_DATABASE_URI'] = database_url or 'sqlite:///' + os.path.j
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 db.init_app(app)
-socketio = SocketIO(app, cors_allowed_origins="*", async_mode='eventlet', ping_timeout=30, ping_interval=5)
+# Use threading mode in tests so SocketIOTestClient works without an eventlet hub.
+_async_mode = 'threading' if _testing else 'eventlet'
+socketio = SocketIO(app, cors_allowed_origins="*", async_mode=_async_mode, ping_timeout=30, ping_interval=5)
 
 # Import routes to register them
 from src.routes import static

--- a/src/sockets/dashboard.py
+++ b/src/sockets/dashboard.py
@@ -202,6 +202,19 @@ def _make_cache_key(*args, **kwargs) -> str:
         key_parts.append(f"{k}={repr(v)}")
     return f"({', '.join(key_parts)})"
 
+def is_success_mode(mode: Optional[str]) -> bool:
+    """Return whether a dashboard mode should display success-rate statistics."""
+    return mode in ('simplified', 'aqmjoe', 'new')
+
+def _get_min_stats_sig_combos(mode: Optional[str]) -> List[Tuple[str, str]]:
+    """Return the ordered item pairs required for dashboard statistical significance."""
+    if mode in ('simplified', 'new'):
+        player1_items = [ItemEnum.A, ItemEnum.B]
+        player2_items = [ItemEnum.X, ItemEnum.Y]
+        return [(i1.value, i2.value) for i1 in player1_items for i2 in player2_items]
+
+    return [(i1.value, i2.value) for i1 in QUESTION_ITEMS for i2 in QUESTION_ITEMS]
+
 def selective_cache(cache_instance: SelectiveCache):
     """
     Decorator for selective caching that supports team-specific invalidation.
@@ -371,7 +384,7 @@ def on_toggle_game_mode() -> None:
 
         # Do not mutate theme here; IFF linking is handled via set_theme_and_mode and theme change handler
         
-        # Clear caches to recalculate with new mode - use force clear since mode affects all calculations
+        # Clear caches to recalculate mode-specific metrics.
         force_clear_all_caches()
         
         # Notify all clients (players and dashboards) about the mode change
@@ -556,7 +569,7 @@ def compute_team_hashes(team_name: str) -> Tuple[str, str]:
 @selective_cache(_success_cache)
 def compute_success_metrics(team_name: str) -> Tuple[List[List[Tuple[int, int]]], List[str], float, float, Dict[Tuple[str, str], int], Dict[Tuple[str, str], int], Dict[str, Dict[str, int]]]:
     """
-    Compute success metrics for new mode instead of correlation matrix.
+    Compute success metrics for success-rate dashboard modes instead of correlation matrix.
     Returns success rate matrix, overall success metrics, and individual player balance data.
     """
     try:
@@ -634,7 +647,7 @@ def compute_success_metrics(team_name: str) -> Tuple[List[List[Tuple[int, int]]]
             player_responses[p1_item]['true' if p1_answer else 'false'] += 1
             player_responses[p2_item]['true' if p2_answer else 'false'] += 1
                 
-            # Apply success rules for new mode
+            # Apply success rules for success-rate dashboard modes
             # Success Rule: {B,Y} combinations require different answers; all others require same answers
             is_by_combination = (p1_item == 'B' and p2_item == 'Y') or (p1_item == 'Y' and p2_item == 'B')
             players_answered_differently = p1_answer != p2_answer
@@ -991,7 +1004,7 @@ def _calculate_team_statistics(team_name: str) -> Dict[str, Optional[float]]:
 
 @selective_cache(_new_stats_cache)
 def _calculate_success_statistics(team_name: str) -> Dict[str, Optional[float]]:
-    """Calculate success statistics for new mode from success metrics for the given team."""
+    """Calculate success statistics for success-rate dashboard modes from success metrics."""
     try:
         # Get success metrics data for this team
         success_result = compute_success_metrics(team_name)
@@ -1047,7 +1060,7 @@ def _calculate_success_statistics(team_name: str) -> Dict[str, Optional[float]]:
             cross_term_avg = 0.0
             cross_term_uncertainty = None
             
-        # Calculate individual player balance for NEW mode
+        # Calculate individual player balance for success-rate dashboard modes
         # Balance measures how evenly each player distributes True/False answers for their question types
         individual_balances = []
         
@@ -1231,7 +1244,7 @@ def _compute_correlation_matrix_optimized(team_id: int, team_rounds: List[Any], 
                 ['A', 'B', 'X', 'Y'], 0.0, {}, {}, {}, {})
 
 def _compute_success_metrics_optimized(team_id: int, team_rounds: List[Any], team_answers: List[Any], team_obj: Any = None) -> Tuple[List[List[Tuple[int, int]]], List[str], float, float, Dict[Tuple[str, str], int], Dict[Tuple[str, str], int], Dict[str, Dict[str, int]]]:
-    """Compute success metrics for new mode using pre-fetched rounds and answers data."""
+    """Compute success metrics for success-rate dashboard modes using pre-fetched data."""
     try:
         # Use pre-fetched team data to avoid N+1 queries
         if team_obj is None:
@@ -1302,7 +1315,7 @@ def _compute_success_metrics_optimized(team_id: int, team_rounds: List[Any], tea
             player_responses[p1_item]['true' if p1_answer else 'false'] += 1
             player_responses[p2_item]['true' if p2_answer else 'false'] += 1
                 
-            # Apply success rules for new mode
+            # Apply success rules for success-rate dashboard modes
             # Success Rule: {B,Y} combinations require different answers; all others require same answers
             is_by_combination = (p1_item == 'B' and p2_item == 'Y') or (p1_item == 'Y' and p2_item == 'B')
             players_answered_differently = p1_answer != p2_answer
@@ -1474,7 +1487,7 @@ def _calculate_team_statistics_from_data(correlation_result: Tuple) -> Dict[str,
         }
 
 def _calculate_success_statistics_from_data(success_result: Tuple) -> Dict[str, Optional[float]]:
-    """Calculate success statistics for new mode from pre-computed success metrics data."""
+    """Calculate success statistics for success-rate dashboard modes from pre-computed data."""
     try:
         (success_matrix_tuples, item_values, overall_success_rate, normalized_cumulative_score, 
          success_counts, pair_counts, player_responses) = success_result
@@ -1523,7 +1536,7 @@ def _calculate_success_statistics_from_data(success_result: Tuple) -> Dict[str, 
             cross_term_avg = 0.0
             cross_term_uncertainty = None
             
-        # Calculate individual player balance for NEW mode
+        # Calculate individual player balance for success-rate dashboard modes
         individual_balances = []
         
         for item, responses in player_responses.items():
@@ -1579,16 +1592,7 @@ def _process_single_team_optimized(team_id: int, team_name: str, is_active: bool
         # For active teams, check game progress
         team_info = state.active_teams.get(team_name)
         
-        # Mode-specific combo calculation for min_stats_sig
-        if state.game_mode == 'new':
-            # New mode: Only A,B x X,Y combinations are possible (Player 1: A/B, Player 2: X/Y)
-            player1_items = [ItemEnum.A, ItemEnum.B]
-            player2_items = [ItemEnum.X, ItemEnum.Y]
-            all_combos = [(i1.value, i2.value) for i1 in player1_items for i2 in player2_items]
-        else:
-            # Classic mode: All combinations possible
-            all_combos = [(i1.value, i2.value) for i1 in QUESTION_ITEMS for i2 in QUESTION_ITEMS]
-            
+        all_combos = _get_min_stats_sig_combos(state.game_mode)
         combo_tracker = team_info.get('combo_tracker', {}) if team_info else {}
         effective_combo_repeats = get_effective_combo_repeats(state.game_mode)
         min_stats_sig = all(combo_tracker.get(combo, 0) >= effective_combo_repeats
@@ -1617,7 +1621,7 @@ def _process_single_team_optimized(team_id: int, team_name: str, is_active: bool
         new_stats = _calculate_success_statistics_from_data(success_result)
         
         # Determine which matrix and stats to use for the main display based on game mode
-        if state.game_mode == 'new':
+        if is_success_mode(state.game_mode):
             display_matrix = success_matrix_tuples
             display_labels = success_item_values
             display_stats = new_stats
@@ -1669,16 +1673,7 @@ def _process_single_team(team_id: int, team_name: str, is_active: bool, created_
         # For active teams, check game progress
         team_info = state.active_teams.get(team_name)
         
-        # Mode-specific combo calculation for min_stats_sig
-        if state.game_mode == 'new':
-            # New mode: Only A,B x X,Y combinations are possible (Player 1: A/B, Player 2: X/Y)
-            player1_items = [ItemEnum.A, ItemEnum.B]
-            player2_items = [ItemEnum.X, ItemEnum.Y]
-            all_combos = [(i1.value, i2.value) for i1 in player1_items for i2 in player2_items]
-        else:
-            # Classic mode: All combinations possible
-            all_combos = [(i1.value, i2.value) for i1 in QUESTION_ITEMS for i2 in QUESTION_ITEMS]
-            
+        all_combos = _get_min_stats_sig_combos(state.game_mode)
         combo_tracker = team_info.get('combo_tracker', {}) if team_info else {}
         effective_combo_repeats = get_effective_combo_repeats(state.game_mode)
         min_stats_sig = all(combo_tracker.get(combo, 0) >= effective_combo_repeats
@@ -1706,7 +1701,7 @@ def _process_single_team(team_id: int, team_name: str, is_active: bool, created_
         new_stats = _calculate_success_statistics(team_name)
         
         # Determine which matrix and stats to use for the main display based on game mode
-        if state.game_mode == 'new':
+        if is_success_mode(state.game_mode):
             display_matrix = success_matrix_tuples
             display_labels = success_item_values
             display_stats = new_stats

--- a/src/sockets/team_management.py
+++ b/src/sockets/team_management.py
@@ -8,7 +8,7 @@ from src.models.quiz_models import Teams, PairQuestionRounds, Answers
 from src.game_logic import start_new_round_for_pair
 import logging
 import time
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Tuple
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -272,7 +272,7 @@ def handle_disconnect() -> None:
     except Exception as e:
         logger.error(f"Disconnect handler error: {str(e)}", exc_info=True)
 
-def _validate_team_name(team_name: Any) -> tuple[bool, str, str]:
+def _validate_team_name(team_name: Any) -> Tuple[bool, str, str]:
     """Validate and canonicalize team name."""
     import re
     if not isinstance(team_name, str):

--- a/src/sockets/team_management.py
+++ b/src/sockets/team_management.py
@@ -84,6 +84,9 @@ def _reactivate_team_internal(team_name: str, sid: str) -> bool:
         # Reactivate the team
         team.is_active = True
         team.player1_session_id = sid
+        # Clear any stale second-player session from previous runs.
+        # The next join should always claim this slot deterministically.
+        team.player2_session_id = None
         db.session.commit()
         # Clear caches after team state change
         _, _, clear_team_caches, _, _ = _import_dashboard_functions()
@@ -410,10 +413,23 @@ def on_join_team(data: Dict[str, Any]) -> None:
         db_team = db.session.get(Teams, team_info['team_id'])
         assigned_slot = None
         if db_team:
-            if not db_team.player1_session_id:
+            # Preserve explicit reconnections first.
+            if db_team.player1_session_id == sid:
+                assigned_slot = 1
+            elif db_team.player2_session_id == sid:
+                assigned_slot = 2
+            elif not db_team.player1_session_id:
                 db_team.player1_session_id = sid
                 assigned_slot = 1
             elif not db_team.player2_session_id:
+                db_team.player2_session_id = sid
+                assigned_slot = 2
+            elif db_team.player1_session_id not in state.connected_players:
+                # Reclaim stale/disconnected slot to avoid blocking round dispatch.
+                db_team.player1_session_id = sid
+                assigned_slot = 1
+            elif db_team.player2_session_id not in state.connected_players:
+                # Reclaim stale/disconnected slot to avoid blocking round dispatch.
                 db_team.player2_session_id = sid
                 assigned_slot = 2
             db_team.is_active = True

--- a/src/sockets/team_management.py
+++ b/src/sockets/team_management.py
@@ -269,15 +269,33 @@ def handle_disconnect() -> None:
     except Exception as e:
         logger.error(f"Disconnect handler error: {str(e)}", exc_info=True)
 
+def _validate_team_name(team_name: Any) -> tuple[bool, str, str]:
+    """Validate and canonicalize team name."""
+    import re
+    if not isinstance(team_name, str):
+        return False, 'Team name is required', ''
+
+    normalized_name = team_name.strip()
+    if not normalized_name:
+        return False, 'Team name is required', ''
+    if not re.fullmatch(r'[a-zA-Z0-9 _\-()]+', normalized_name):
+        return False, 'Team name may only contain letters, numbers, spaces, and - _ ( )', ''
+    if len(normalized_name) > 50:
+        return False, 'Team name must be 50 characters or fewer', ''
+    return True, '', normalized_name
+
 @socketio.on('create_team')
 def on_create_team(data: Dict[str, Any]) -> None:
     try:
-        team_name = data.get('team_name')
+        raw_team_name = data.get('team_name') if isinstance(data, dict) else None
         sid = request.sid  # type: ignore
-        if not team_name:
-            emit('error', {'message': 'Team name is required'})  # type: ignore
+
+        # Validate team name format
+        is_valid, error_msg, team_name = _validate_team_name(raw_team_name)
+        if not is_valid:
+            emit('error', {'message': error_msg})  # type: ignore
             return
-            
+
         # Check if team name already exists as active team
         if team_name in state.active_teams or Teams.query.filter_by(team_name=team_name, is_active=True).first():
             emit('error', {'message': 'Team name already exists or is active'})  # type: ignore

--- a/src/state.py
+++ b/src/state.py
@@ -13,8 +13,8 @@ class AppState:
         self.game_paused = False # Track if game is paused
         self.answer_stream_enabled = False # Track if answer streaming is enabled
         # Internal storage for game mode with normalization
-        self._game_mode = 'simplified'  # Track current game mode: 'classic', 'simplified', or 'aqmjoe'
-        self.game_theme = 'food'  # Track current game theme: 'classic', 'food', etc.
+        self._game_mode = 'aqmjoe'  # Track current game mode: 'classic', 'simplified', or 'aqmjoe'
+        self.game_theme = 'aqmjoe'  # Track current game theme: 'classic', 'food', etc.
         # Store team ID to team name mapping for faster lookups
         self.team_id_to_name = {} # {team_id: team_name}
         # Track disconnected players for reconnection - maps team_name to disconnected player info
@@ -46,8 +46,8 @@ class AppState:
         self.game_started = False
         self.game_paused = False
         self.answer_stream_enabled = False
-        self.game_mode = 'simplified'  # Reset game mode to simplified
-        self.game_theme = 'food'  # Reset game theme to food
+        self.game_mode = 'aqmjoe'  # Reset game mode to aqmjoe
+        self.game_theme = 'aqmjoe'  # Reset game theme to aqmjoe
 
     def get_player_slot(self, team_name, sid):
         """Get the database player slot (1 or 2) for a session ID in a team"""

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -375,6 +375,8 @@ function updateTeamsList(teams) {
             
             const joinButton = document.createElement('button');
             joinButton.className = 'join-btn';
+            joinButton.setAttribute('data-team-name', team.team_name);
+            joinButton.setAttribute('aria-label', 'Join team: ' + team.team_name);
             joinButton.textContent = 'Join Team';
             joinButton.onclick = (e) => {
                 e.stopPropagation();
@@ -401,6 +403,8 @@ function updateTeamsList(teams) {
             
             const reactivateButton = document.createElement('button');
             reactivateButton.className = 'reactivate-btn';
+            reactivateButton.setAttribute('data-team-name', team.team_name);
+            reactivateButton.setAttribute('aria-label', 'Reactivate and join: ' + team.team_name);
             reactivateButton.textContent = 'Reactivate & Join';
             reactivateButton.onclick = (e) => {
                 e.stopPropagation();
@@ -426,7 +430,15 @@ function createTeam() {
         showStatus('Please enter a team name', 'error');
         return;
     }
-    
+    if (!/^[a-zA-Z0-9 _\-()]+$/.test(teamName)) {
+        showStatus('Team name may only contain letters, numbers, spaces, and - _ ( )', 'error');
+        return;
+    }
+    if (teamName.length > 50) {
+        showStatus('Team name must be 50 characters or fewer', 'error');
+        return;
+    }
+
     socket.emit('create_team', { team_name: teamName });
     showStatus('Creating team...', 'info');
 }

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -8,8 +8,8 @@ let lastClickedButton = null;
 let sessionId = null;
 let teamId = null;
 let currentTeamStatus = null; // Track current team status
-let currentGameMode = 'simplified'; // Track current game mode
-let currentGameTheme = 'food'; // Track current game theme
+let currentGameMode = 'aqmjoe'; // Track current game mode
+let currentGameTheme = 'aqmjoe'; // Track current game theme
 let playerPosition = null; // Track player position (1 or 2)
 let lastRoundResults = null; // Track last round results for display
 
@@ -23,6 +23,7 @@ const availableTeams = document.getElementById('availableTeams');
 const inactiveTeams = document.getElementById('inactiveTeams');
 const gameHeader = document.getElementById('gameHeader');
 const questionItem = document.getElementById('questionItem');
+const questionContainer = document.getElementById('questionContainer');
 const trueBtn = document.getElementById('trueBtn');
 const falseBtn = document.getElementById('falseBtn');
 const waitingMessage = document.getElementById('waitingMessage');
@@ -87,6 +88,22 @@ function updateButtonText() {
         trueBtn.textContent = 'True';
         falseBtn.textContent = 'False';
     }
+    updateAnswerAccessibilityLabels();
+}
+
+function updateQuestionAccessibilityLabel(questionText) {
+    if (!questionContainer) {
+        return;
+    }
+    const text = (questionText || '').trim();
+    questionContainer.setAttribute('aria-label', text ? `Question: ${text}` : 'Question');
+}
+
+function updateAnswerAccessibilityLabels() {
+    const trueText = (trueBtn.textContent || 'True').trim();
+    const falseText = (falseBtn.textContent || 'False').trim();
+    trueBtn.setAttribute('aria-label', `Answer option: ${trueText}`);
+    falseBtn.setAttribute('aria-label', `Answer option: ${falseText}`);
 }
 
 // Update game mode (only log to console, don't show in UI)
@@ -177,12 +194,12 @@ function resetToInitialView() {
     teamId = null;
     currentTeamStatus = null; // Reset team status
     playerPosition = null; // Reset player position
-    currentGameMode = 'simplified'; // Reset to simplified mode
-    currentGameTheme = 'food'; // Reset to food theme
+    currentGameMode = 'aqmjoe'; // Reset to default mode
+    currentGameTheme = 'aqmjoe'; // Reset to default theme
     localStorage.removeItem('quizSessionData');
     updatePlayerPosition(null);
-    updateGameMode('simplified');
-    updateGameTheme('food');
+    updateGameMode('aqmjoe');
+    updateGameTheme('aqmjoe');
     updateGameState(); // This will show team creation/joining
     showStatus('Disconnected, try refreshing the page.', 'info');
 }
@@ -225,6 +242,7 @@ function updateGameState(newGameStarted = null, isReset = false) {
         if (window.themeManager && currentRound.item) {
             const themedItem = window.themeManager.getItemDisplay(currentRound.item);
             questionItem.textContent = themedItem;
+            updateQuestionAccessibilityLabel(themedItem);
             
             // Apply theme colors
             const questionDiv = questionItem.closest('.question');
@@ -239,6 +257,7 @@ function updateGameState(newGameStarted = null, isReset = false) {
         } else {
             // Fallback to raw item
             questionItem.textContent = currentRound.item;
+            updateQuestionAccessibilityLabel(currentRound.item);
             updateButtonText();
         }
         
@@ -284,6 +303,7 @@ function updateGameState(newGameStarted = null, isReset = false) {
         teamSection.style.display = 'none';
         questionSection.style.display = 'block';
         questionItem.textContent = "...";
+        updateQuestionAccessibilityLabel("...");
         
         // Apply theme colors even for placeholder
         if (window.themeManager) {
@@ -326,6 +346,7 @@ function resetGameControls() {
     falseBtn.disabled = false;
     waitingMessage.classList.remove('visible');
     questionItem.textContent = '';
+    updateQuestionAccessibilityLabel('');
     currentRound = null;
     
     // Apply default theme styling
@@ -687,6 +708,7 @@ const callbacks = {
         if (window.themeManager && data.item) {
             const themedItem = window.themeManager.getItemDisplay(data.item);
             questionItem.textContent = themedItem;
+            updateQuestionAccessibilityLabel(themedItem);
             
             // Apply theme colors
             const questionDiv = questionItem.closest('.question');
@@ -701,6 +723,7 @@ const callbacks = {
         } else {
             // Fallback to raw item
             questionItem.textContent = data.item;
+            updateQuestionAccessibilityLabel(data.item);
             updateButtonText();
         }
         
@@ -766,6 +789,10 @@ initializeSocketHandlers(socket, callbacks);
 createTeamBtn.addEventListener('click', createTeam);
 trueBtn.addEventListener('click', () => submitAnswer(true));
 falseBtn.addEventListener('click', () => submitAnswer(false));
+
+// Initial accessibility labels for participant controls.
+updateQuestionAccessibilityLabel(questionItem.textContent || '');
+updateAnswerAccessibilityLabels();
 
 // Initialize all collapsible sections
 document.addEventListener('DOMContentLoaded', function() {

--- a/src/static/dashboard.html
+++ b/src/static/dashboard.html
@@ -51,8 +51,8 @@
                 <div class="metric-card">
                     <h3 id="game-control-text">Game Control</h3>
                     <div class="game-controls">
-                        <button id="start-game-btn" onclick="startGame()" style="border: 2px solid #4CAF50;">Start Game</button>
-                        <button id="pause-game-btn" onclick="togglePause()" style="border: 2px solid #FFC107;">Pause</button>
+                        <button id="start-game-btn" onclick="startGame()" style="border: 2px solid #4CAF50;" aria-label="Start game">Start Game</button>
+                        <button id="pause-game-btn" onclick="togglePause()" style="border: 2px solid #FFC107;" aria-label="Pause game">Pause</button>
                     </div>
                 </div>
             </div>
@@ -190,7 +190,7 @@
                         <div class="reset-description">
                             Reset all game statistics and remove inactive teams.
                         </div>
-                        <button id="reset-game-btn" onclick="handleResetGame()" class="control-btn reset-btn" style="display: none;">
+                        <button id="reset-game-btn" onclick="handleResetGame()" class="control-btn reset-btn" style="display: none;" aria-label="Reset game stats">
                             Reset Game Stats
                         </button>
                     </div>
@@ -204,7 +204,7 @@
                             <span>Current Mode: </span>
                             <span id="current-game-mode" class="mode-indicator">New</span>
                         </div>
-                        <button id="toggle-mode-btn" onclick="toggleGameMode()" class="control-btn mode-toggle-btn">
+                        <button id="toggle-mode-btn" onclick="toggleGameMode()" class="control-btn mode-toggle-btn" aria-label="Toggle game mode">
                             Switch to Classic Mode
                         </button>
                         <div class="mode-description">

--- a/src/static/dashboard.html
+++ b/src/static/dashboard.html
@@ -202,15 +202,14 @@
                     <div class="game-mode-controls">
                         <div class="current-mode-display">
                             <span>Current Mode: </span>
-                            <span id="current-game-mode" class="mode-indicator">New</span>
+                            <span id="current-game-mode" class="mode-indicator">AQM Joe</span>
                         </div>
                         <button id="toggle-mode-btn" onclick="toggleGameMode()" class="control-btn mode-toggle-btn" aria-label="Toggle game mode">
-                            Switch to Classic Mode
+                            Switch to Simplified Mode
                         </button>
                         <div class="mode-description">
                             <div id="mode-description-text">
-                                <strong>New Mode:</strong> Player 1 receives only A/B questions, Player 2 receives only X/Y questions. 
-                                Metrics focus on success rates and optimal strategy adherence.
+                                <strong>AQM Joe Mode:</strong> Both players may get any of A/B/X/Y. Success-rate scoreboard uses the AQM Joe policy, including Color–Color and Food–Food pairs.
                             </div>
                         </div>
                     </div>
@@ -222,20 +221,19 @@
                     <div class="theme-controls">
                         <div class="current-theme-display">
                             <span>Current Theme: </span>
-                            <span id="current-game-theme" class="theme-indicator">Food</span>
+                            <span id="current-game-theme" class="theme-indicator">AQM Joe</span>
                         </div>
                         <div class="theme-selector">
                             <label for="theme-dropdown">Select Theme:</label>
                             <select id="theme-dropdown" class="control-btn theme-dropdown">
-                                <option value="food" selected>Food Ingredients (🍞, 🥟, 🥬, 🍫)</option>
+                                <option value="food">Food Ingredients (🍞, 🥟, 🥬, 🍫)</option>
                                 <option value="classic">Classic (A, B, X, Y)</option>
-                                <option value="aqmjoe">AQM Joe (Color/Food)</option>
+                                <option value="aqmjoe" selected>AQM Joe (Color/Food)</option>
                             </select>
                         </div>
                         <div class="theme-description">
                             <div id="theme-description-text">
-                                <strong>Food Ingredients Theme:</strong> Questions use cooking ingredients (🍞 Bread, 🥟 Dumplings, 🥬 Lettuce, 🍫 Chocolate). 
-                                Game rules are themed around cooking and recipe coordination.
+                                <strong>AQM Joe Theme:</strong> For color questions (A/B), answer Green/Red; for food questions (X/Y), answer Peas/Carrots.
                             </div>
                         </div>
                     </div>

--- a/src/static/dashboard.js
+++ b/src/static/dashboard.js
@@ -13,10 +13,10 @@ document.addEventListener('change', (event) => {
 });
 
 // Game mode state
-let currentGameMode = 'simplified';
+let currentGameMode = 'aqmjoe';
 
 // Theme state  
-let currentGameTheme = 'food';
+let currentGameTheme = 'aqmjoe';
 
 // Handle page visibility changes
 document.addEventListener('visibilitychange', () => {
@@ -84,11 +84,11 @@ function updateGameModeDisplay(mode) {
     const modeDescription = document.getElementById('mode-description-text');
     
     // Add CSS class to body to control column visibility
-    document.body.className = document.body.className.replace(/\b(classic|new)-mode\b/g, '');
+    document.body.className = document.body.className.replace(/\b(classic|simplified|aqmjoe|new)-mode\b/g, '');
     document.body.classList.add(`${mode}-mode`);
     
     if (modeIndicator) {
-        modeIndicator.textContent = mode.charAt(0).toUpperCase() + mode.slice(1);
+        modeIndicator.textContent = mode === 'aqmjoe' ? 'AQM Joe' : mode.charAt(0).toUpperCase() + mode.slice(1);
         modeIndicator.className = `mode-indicator ${mode}`;
     }
     
@@ -148,7 +148,7 @@ function updateGameThemeDisplay(theme, skipDropdownUpdate = false) {
     const themeDescription = document.getElementById('theme-description-text');
     
     if (themeIndicator) {
-        themeIndicator.textContent = theme.charAt(0).toUpperCase() + theme.slice(1);
+        themeIndicator.textContent = theme === 'aqmjoe' ? 'AQM Joe' : theme.charAt(0).toUpperCase() + theme.slice(1);
     }
     
     if (themeDropdown && !skipDropdownUpdate) {
@@ -160,6 +160,10 @@ function updateGameThemeDisplay(theme, skipDropdownUpdate = false) {
             themeDescription.innerHTML = `
                 <strong>Food Ingredients Theme:</strong> Questions use cooking ingredients (🍞 Bread, 🥟 Dumplings, 🥬 Lettuce, 🍫 Chocolate). 
                 Game rules are themed around cooking and recipe coordination.
+            `;
+        } else if (theme === 'aqmjoe') {
+            themeDescription.innerHTML = `
+                <strong>AQM Joe Theme:</strong> For color questions (A/B), answer Green/Red; for food questions (X/Y), answer Peas/Carrots.
             `;
         } else {
             themeDescription.innerHTML = `

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -32,9 +32,9 @@
             <div id="createTeamSection">
                 <h3>Create a New Team</h3>
                 <div class="form-group">
-                    <input type="text" id="teamNameInput" placeholder="Enter Team Name">
+                    <input type="text" id="teamNameInput" placeholder="Enter Team Name" aria-label="Team name" maxlength="50">
                 </div>
-                <button id="createTeamBtn">Create Team</button>
+                <button id="createTeamBtn" aria-label="Create team">Create Team</button>
             </div>
             
             <!-- Join Team Section -->
@@ -63,8 +63,8 @@
             <div class="question-container">
                 <div class="question"><span id="questionItem"></span></div>
                 <div class="answer-buttons">
-                    <button id="trueBtn" class="answer-button true-button">True</button>
-                    <button id="falseBtn" class="answer-button false-button">False</button>
+                    <button id="trueBtn" class="answer-button true-button" aria-label="Answer true">True</button>
+                    <button id="falseBtn" class="answer-button false-button" aria-label="Answer false">False</button>
                 </div>
             </div>
             <div id="waitingMessage" class="status-message info">

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -61,7 +61,9 @@
         <!-- Question Section (Initially Hidden) -->
         <div id="questionSection" class="hidden">
             <div class="question-container">
-                <div class="question"><span id="questionItem"></span></div>
+                <div class="question" id="questionContainer" role="status" aria-live="polite" aria-atomic="true">
+                    <span id="questionItem"></span>
+                </div>
                 <div class="answer-buttons">
                     <button id="trueBtn" class="answer-button true-button" aria-label="Answer true">True</button>
                     <button id="falseBtn" class="answer-button false-button" aria-label="Answer false">False</button>

--- a/src/static/themes.js
+++ b/src/static/themes.js
@@ -271,8 +271,8 @@ const THEMES = {
 // Theme utility functions
 class ThemeManager {
     constructor() {
-        this.currentTheme = 'food';
-        this.currentMode = 'simplified';
+        this.currentTheme = 'aqmjoe';
+        this.currentMode = 'aqmjoe';
     }
     
     setTheme(themeName) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,10 @@ from typing import Optional, IO, Any
 # Add the project root to the path so we can import modules
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+# Prevent eventlet.monkey_patch() from running in the test process.
+# src/config.py checks this flag; it must be set before any src imports.
+os.environ.setdefault('TESTING', '1')
+
 # Global variable to track server process
 _server_process = None
 
@@ -108,15 +112,19 @@ def flask_server(pytestconfig, request):
         yield None
         return
     
-    # Start the server using gunicorn with eventlet worker
+    # Start the server using gunicorn with eventlet worker.
+    # TESTING is stripped from the subprocess env so src/config.py
+    # applies eventlet.monkey_patch() as normal inside the server process.
+    # Use the absolute path to gunicorn so this works with or without an activated venv.
+    server_env = {k: v for k, v in os.environ.items() if k != 'TESTING'}
+    gunicorn_bin = os.path.join(os.path.dirname(sys.executable), 'gunicorn')
     server_cmd = [
-        'gunicorn', 
+        gunicorn_bin,
         'wsgi:app',
         '--worker-class', 'eventlet',
         '--bind', '0.0.0.0:8080',
         '--timeout', '30',
-        '--preload',
-        '--log-level', 'info'
+        '--log-level', 'info',
     ]
     
     output_queue: queue.Queue = queue.Queue()
@@ -127,6 +135,7 @@ def flask_server(pytestconfig, request):
         print("Starting Flask server for integration tests...")
         _server_process = subprocess.Popen(
             server_cmd,
+            env=server_env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             preexec_fn=os.setsid  # Create new process group

--- a/tests/integration/test_aqmjoe_integration.py
+++ b/tests/integration/test_aqmjoe_integration.py
@@ -1,13 +1,19 @@
 import pytest
 import tempfile
 import os
+import random
 from unittest.mock import patch, MagicMock
 
 from src.config import app, db
 from src.state import state
 from src.models.quiz_models import Teams, PairQuestionRounds, Answers, ItemEnum
-from src.game_logic import start_new_round_for_pair
-from src.sockets.dashboard import compute_success_metrics, on_set_theme_and_mode, on_change_game_theme
+from src.game_logic import TARGET_COMBO_REPEATS, start_new_round_for_pair
+from src.sockets.dashboard import (
+    _process_single_team,
+    compute_success_metrics,
+    on_set_theme_and_mode,
+    on_change_game_theme,
+)
 
 
 class TestAQMJoeIntegration:
@@ -115,6 +121,108 @@ class TestAQMJoeIntegration:
             # Validate Food–Food both Peas counted as failure
             assert pair_counts.get(('X', 'Y')) == 1
             assert success_counts.get(('X', 'Y'), 0) == 0
+
+    def test_aqmjoe_perfect_team_beats_seeded_random_team_after_stats_sig(self):
+        state.game_mode = 'aqmjoe'
+        item_values = [ItemEnum.A, ItemEnum.B, ItemEnum.X, ItemEnum.Y]
+        all_combos = [(p1_item, p2_item) for p1_item in item_values for p2_item in item_values]
+        combo_tracker = {
+            (p1_item.value, p2_item.value): TARGET_COMBO_REPEATS
+            for p1_item, p2_item in all_combos
+        }
+
+        def create_team(team_name, p1_sid, p2_sid):
+            team = Teams(team_name=team_name, is_active=True)
+            team.player1_session_id = p1_sid
+            team.player2_session_id = p2_sid
+            db.session.add(team)
+            db.session.flush()
+            state.active_teams[team_name] = {
+                'team_id': team.team_id,
+                'players': [p1_sid, p2_sid],
+                'current_round_number': len(all_combos) * TARGET_COMBO_REPEATS,
+                'combo_tracker': dict(combo_tracker),
+                'current_db_round_id': None,
+                'answered_current_round': {},
+                'player_slots': {p1_sid: 1, p2_sid: 2},
+                'status': 'active',
+            }
+            return team
+
+        def add_round(team, round_no, p1_item, p2_item, p1_answer, p2_answer):
+            rnd = PairQuestionRounds(
+                team_id=team.team_id,
+                round_number_for_team=round_no,
+                player1_item=p1_item,
+                player2_item=p2_item,
+            )
+            db.session.add(rnd)
+            db.session.flush()
+            db.session.add(Answers(
+                team_id=team.team_id,
+                question_round_id=rnd.round_id,
+                player_session_id=team.player1_session_id,
+                assigned_item=p1_item,
+                response_value=p1_answer,
+            ))
+            db.session.add(Answers(
+                team_id=team.team_id,
+                question_round_id=rnd.round_id,
+                player_session_id=team.player2_session_id,
+                assigned_item=p2_item,
+                response_value=p2_answer,
+            ))
+
+        with app.app_context():
+            perfect_team = create_team('perfect_team', 'perfect_p1', 'perfect_p2')
+            random_team = create_team('random_team', 'random_p1', 'random_p2')
+            rng = random.Random(20260506)
+
+            round_no = 0
+            for _ in range(TARGET_COMBO_REPEATS):
+                for p1_item, p2_item in all_combos:
+                    round_no += 1
+                    # False/False is Red/Carrots, which satisfies every AQM Joe pair.
+                    add_round(perfect_team, round_no, p1_item, p2_item, False, False)
+                    add_round(
+                        random_team,
+                        round_no,
+                        p1_item,
+                        p2_item,
+                        rng.choice([True, False]),
+                        rng.choice([True, False]),
+                    )
+            db.session.commit()
+
+            _process_single_team.cache_clear()
+            perfect_data = _process_single_team(
+                perfect_team.team_id, 'perfect_team', True, '2026-05-06', round_no,
+                perfect_team.player1_session_id, perfect_team.player2_session_id,
+            )
+            _process_single_team.cache_clear()
+            random_data = _process_single_team(
+                random_team.team_id, 'random_team', True, '2026-05-06', round_no,
+                random_team.player1_session_id, random_team.player2_session_id,
+            )
+
+        assert perfect_data is not None
+        assert random_data is not None
+        assert perfect_data['min_stats_sig'] is True
+        assert random_data['min_stats_sig'] is True
+        assert perfect_data['correlation_stats'] == perfect_data['new_stats']
+        assert random_data['correlation_stats'] == random_data['new_stats']
+
+        perfect_rate = perfect_data['new_stats']['trace_average_statistic']
+        random_rate = random_data['new_stats']['trace_average_statistic']
+        assert perfect_rate == 1.0
+        assert 0.0 <= random_rate < perfect_rate
+
+        eligible_teams = [perfect_data, random_data]
+        trophy_team = max(
+            eligible_teams,
+            key=lambda team: team['new_stats']['trace_average_statistic'],
+        )
+        assert trophy_team['team_name'] == 'perfect_team'
 
     def test_theme_mode_linking_and_alias_handling(self):
         # Real socket path for on_change_game_theme (linking enforced)

--- a/tests/integration/test_player_interaction.py
+++ b/tests/integration/test_player_interaction.py
@@ -1,11 +1,12 @@
-import eventlet
-eventlet.monkey_patch()  # This must be at the very top
-
 import pytest
 import time
 import logging
 from flask_socketio import SocketIOTestClient
 from src.config import app, socketio as server_socketio
+# Importing these modules registers their @socketio.on handlers with server_socketio.
+import src.sockets.team_management  # noqa: F401
+import src.sockets.game  # noqa: F401
+import src.sockets.dashboard  # noqa: F401
 from src.state import state
 from src.models.quiz_models import (
     Teams,
@@ -156,7 +157,7 @@ class TestPlayerInteraction:
         """Helper method to wait for and get a specific event"""
         start_time = time.time()
         while (time.time() - start_time) < timeout:
-            eventlet.sleep(0.1)  # type: ignore
+            time.sleep(0.1)  # type: ignore
             event = self.get_received_event(client, event_name)
             if event is not None:
                 return event
@@ -211,7 +212,7 @@ class TestPlayerInteraction:
                 'item': 'Y' if round_num % 2 == 0 else 'X',
                 'answer': False
             })
-            eventlet.sleep(0.2)
+            time.sleep(0.2)
 
             # Verify answer confirmations
             return (
@@ -232,7 +233,7 @@ class TestPlayerInteraction:
         
         # Create team
         socket_client.emit('create_team', {'team_name': 'TestTeam'})
-        eventlet.sleep(0.2)  # Use eventlet sleep instead of time.sleep
+        time.sleep(0.2)  # Use eventlet sleep instead of time.sleep
 
         # Get all messages since team creation
         messages = socket_client.get_received()
@@ -256,7 +257,7 @@ class TestPlayerInteraction:
         # Setup and create team with first client
         self.verify_connection(socket_client)
         socket_client.emit('create_team', {'team_name': 'TeamToJoin'})
-        eventlet.sleep(0.2)  # Use eventlet sleep
+        time.sleep(0.2)  # Use eventlet sleep
         socket_client.get_received()  # Clear messages
 
         # Connect second client and join team
@@ -264,7 +265,7 @@ class TestPlayerInteraction:
         second_client.get_received()  # Clear connection messages
         
         second_client.emit('join_team', {'team_name': 'TeamToJoin'})
-        eventlet.sleep(0.2)  # Use eventlet sleep
+        time.sleep(0.2)  # Use eventlet sleep
 
         # Get all messages since team join
         p2_messages = second_client.get_received()
@@ -299,7 +300,7 @@ class TestPlayerInteraction:
 
         self.verify_connection(second_client)
         second_client.emit('join_team', {'team_name': 'AnswerTeam'})
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         second_client.get_received()
 
         # Turn on game state
@@ -327,7 +328,7 @@ class TestPlayerInteraction:
             'item': 'X',  # Use valid ItemEnum value
             'answer': True
         })
-        eventlet.sleep(0.2)  # Use eventlet sleep
+        time.sleep(0.2)  # Use eventlet sleep
         
         # Get all messages since answer submission
         messages = socket_client.get_received()
@@ -349,7 +350,7 @@ class TestPlayerInteraction:
 
         # Leave team
         socket_client.emit('leave_team', {})  # Socket event requires data object
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
 
         # Get messages after leaving
         messages = socket_client.get_received()
@@ -375,7 +376,7 @@ class TestPlayerInteraction:
 
         self.verify_connection(second_client)
         second_client.emit('join_team', {'team_name': 'MultiRoundTeam'})
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         second_client.get_received()
 
         # Start game
@@ -428,7 +429,7 @@ class TestPlayerInteraction:
                     'item': 'Y' if round_num % 2 == 0 else 'X',
                     'answer': False
                 })
-                eventlet.sleep(0.2)
+                time.sleep(0.2)
                 
                 p1_confirm = self.wait_for_event(socket_client, 'answer_confirmed')
                 p2_confirm = self.wait_for_event(second_client, 'answer_confirmed')
@@ -456,7 +457,7 @@ class TestPlayerInteraction:
         # Pause game
         state.game_paused = True
         server_socketio.emit('game_paused')
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
 
         # Verify pause event received
         pause_event = self.wait_for_event(socket_client, 'game_paused')
@@ -465,7 +466,7 @@ class TestPlayerInteraction:
         # Resume game
         state.game_paused = False
         server_socketio.emit('game_resumed')
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
 
         # Verify resume event received
         resume_event = self.wait_for_event(socket_client, 'game_resumed')
@@ -595,7 +596,7 @@ class TestPlayerInteraction:
                 'item': 'Y',
                 'answer': p2_answer
             })
-            eventlet.sleep(0.2)
+            time.sleep(0.2)
 
             # Verify answer confirmations
             p1_confirm = self.wait_for_event(socket_client, 'answer_confirmed')
@@ -625,17 +626,17 @@ class TestPlayerInteraction:
         # Create dashboard client
         dashboard_client = SocketIOTestClient(app, server_socketio)
         dashboard_client.emit('dashboard_join')
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         dashboard_client.get_received()
         
         # Enable teams streaming
         dashboard_client.emit('set_teams_streaming', {'enabled': True})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         dashboard_client.get_received()
         
         # Request teams update after enabling streaming
         dashboard_client.emit('request_teams_update')
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         dashboard_client.get_received()
 
         # Player 1 creates team
@@ -657,7 +658,7 @@ class TestPlayerInteraction:
 
         # Player 2 disconnects
         self.simulate_disconnect(second_client)
-        eventlet.sleep(0.5)  # Increased time for disconnect processing and throttling
+        time.sleep(0.5)  # Increased time for disconnect processing and throttling
         
         # FIXED: Use helper method to check status with throttling support
         found = self.check_dashboard_team_status(dashboard_client, 'DisconnectTeam', 'waiting_pair')
@@ -665,7 +666,7 @@ class TestPlayerInteraction:
 
         # Player 1 disconnects
         self.simulate_disconnect(socket_client)
-        eventlet.sleep(0.5)  # Increased time for disconnect processing and throttling
+        time.sleep(0.5)  # Increased time for disconnect processing and throttling
         
         # FIXED: Use helper method to check status with throttling support
         found = self.check_dashboard_team_status(dashboard_client, 'DisconnectTeam', 'inactive')
@@ -677,17 +678,17 @@ class TestPlayerInteraction:
         """Two players form a team, both disconnect, one reconnects (reactivates team), dashboard reflects this."""
         dashboard_client = SocketIOTestClient(app, server_socketio)
         dashboard_client.emit('dashboard_join')
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         dashboard_client.get_received()
         
         # Enable teams streaming
         dashboard_client.emit('set_teams_streaming', {'enabled': True})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         dashboard_client.get_received()
         
         # Request teams update after enabling streaming
         dashboard_client.emit('request_teams_update')
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         dashboard_client.get_received()
 
         # Player 1 creates team
@@ -706,21 +707,21 @@ class TestPlayerInteraction:
         # Both disconnect
         self.simulate_disconnect(second_client)
         self.simulate_disconnect(socket_client)
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         dashboard_client.get_received()
 
         # Player 1 reconnects and reactivates team
         new_client = SocketIOTestClient(app, server_socketio)
         self.verify_connection(new_client)
         new_client.emit('reactivate_team', {'team_name': 'ReactivateTeam'})
-        eventlet.sleep(0.8)  # Increased time for server to process reactivation and clear cache
+        time.sleep(0.8)  # Increased time for server to process reactivation and clear cache
         new_client.get_received()
 
         # Dashboard should see team as waiting_pair
         dashboard_client.emit('dashboard_join')  # First join to trigger update
-        eventlet.sleep(0.5)  # Increased wait for throttling
+        time.sleep(0.5)  # Increased wait for throttling
         dashboard_client.emit('dashboard_join')  # Second join to ensure cache refresh
-        eventlet.sleep(0.5)  # Increased wait for throttling
+        time.sleep(0.5)  # Increased wait for throttling
         dash_msgs = dashboard_client.get_received()
         found = False
         for msg in dash_msgs:
@@ -738,12 +739,12 @@ class TestPlayerInteraction:
         """Dashboard client sees correct team/player status after each disconnect/reconnect."""
         dashboard_client = SocketIOTestClient(app, server_socketio)
         dashboard_client.emit('dashboard_join')
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         dashboard_client.get_received()
         
         # Enable teams streaming
         dashboard_client.emit('set_teams_streaming', {'enabled': True})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         dashboard_client.get_received()
 
         # Player 1 creates team
@@ -765,7 +766,7 @@ class TestPlayerInteraction:
 
         # Player 2 disconnects, dashboard sees waiting_pair
         self.simulate_disconnect(second_client)
-        eventlet.sleep(0.5)  # Increased time for disconnect processing and throttling
+        time.sleep(0.5)  # Increased time for disconnect processing and throttling
         
         # FIXED: Use helper method to check status with throttling support
         found = self.check_dashboard_team_status(dashboard_client, 'DashStatusTeam', 'waiting_pair')
@@ -789,12 +790,12 @@ class TestPlayerInteraction:
         """Edge case: Player disconnects and reconnects with same SID, dashboard and team state remain consistent."""
         dashboard_client = SocketIOTestClient(app, server_socketio)
         dashboard_client.emit('dashboard_join')
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         dashboard_client.get_received()
         
         # Enable teams streaming
         dashboard_client.emit('set_teams_streaming', {'enabled': True})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         dashboard_client.get_received()
 
         # Player 1 creates team
@@ -812,7 +813,7 @@ class TestPlayerInteraction:
 
         # Player 2 disconnects
         self.simulate_disconnect(second_client)
-        eventlet.sleep(0.5)  # Increased time for disconnect processing and throttling
+        time.sleep(0.5)  # Increased time for disconnect processing and throttling
         
         # FIXED: Use helper method to check status with throttling support
         found = self.check_dashboard_team_status(dashboard_client, 'ReconnectSIDTeam', 'waiting_pair')
@@ -837,12 +838,12 @@ class TestPlayerInteraction:
         """Edge case: Two teams, one loses a player, dashboard only updates that team's status."""
         dashboard_client = SocketIOTestClient(app, server_socketio)
         dashboard_client.emit('dashboard_join')
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         dashboard_client.get_received()
         
         # Enable teams streaming
         dashboard_client.emit('set_teams_streaming', {'enabled': True})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         dashboard_client.get_received()
 
         # Team 1
@@ -875,7 +876,7 @@ class TestPlayerInteraction:
 
         # TeamOne loses a player
         self.simulate_disconnect(client2a)
-        eventlet.sleep(0.5)  # Increased time for disconnect processing and throttling
+        time.sleep(0.5)  # Increased time for disconnect processing and throttling
         
         # FIXED: Check each team status individually with throttling support
         found_waiting = self.check_dashboard_team_status(dashboard_client, 'TeamOne', 'waiting_pair')
@@ -893,12 +894,12 @@ class TestPlayerInteraction:
         """Two players rapidly join and leave a team multiple times, dashboard always reflects correct status."""
         dashboard_client = SocketIOTestClient(app, server_socketio)
         dashboard_client.emit('dashboard_join')
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         dashboard_client.get_received()
         
         # Enable teams streaming
         dashboard_client.emit('set_teams_streaming', {'enabled': True})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         dashboard_client.get_received()
         for i in range(3):
             player1 = SocketIOTestClient(app, server_socketio)
@@ -915,7 +916,7 @@ class TestPlayerInteraction:
             player2.get_received()
             # Player 2 leaves
             player2.emit('leave_team', {})
-            eventlet.sleep(0.2)
+            time.sleep(0.2)
             player2.get_received()
             # Player 2 rejoins
             player2.emit('join_team', {'team_name': f'RapidTeam{i}'})
@@ -923,7 +924,7 @@ class TestPlayerInteraction:
             player2.get_received()
             # Player 1 leaves
             player1.emit('leave_team', {})
-            eventlet.sleep(0.2)
+            time.sleep(0.2)
             player1.get_received()
             # Dashboard should see team as inactive or waiting_pair (teams streaming enabled above)
             self.force_fresh_dashboard_update(dashboard_client)
@@ -945,12 +946,12 @@ class TestPlayerInteraction:
         """Both players disconnect at nearly the same time, team becomes inactive, dashboard reflects this."""
         dashboard_client = SocketIOTestClient(app, server_socketio)
         dashboard_client.emit('dashboard_join')
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         dashboard_client.get_received()
         
         # Enable teams streaming
         dashboard_client.emit('set_teams_streaming', {'enabled': True})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         dashboard_client.get_received()
         self.verify_connection(socket_client)
         socket_client.emit('create_team', {'team_name': 'SimulTeam'})
@@ -963,7 +964,7 @@ class TestPlayerInteraction:
         # Both disconnect nearly simultaneously
         self.simulate_disconnect(second_client)
         self.simulate_disconnect(socket_client)
-        eventlet.sleep(0.5)
+        time.sleep(0.5)
         # Use force refresh to ensure fresh data (teams streaming enabled above)
         self.force_fresh_dashboard_update(dashboard_client)
         dash_msgs = dashboard_client.get_received()
@@ -990,16 +991,16 @@ class TestPlayerInteraction:
         second_client.get_received()
         # Both leave
         second_client.emit('leave_team', {})
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         second_client.get_received()
         socket_client.emit('leave_team', {})
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         socket_client.get_received()
         # Try to join as a new client before reactivation
         new_client = SocketIOTestClient(app, server_socketio)
         self.verify_connection(new_client)
         new_client.emit('join_team', {'team_name': 'InactiveTeam'})
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         msgs = new_client.get_received()
         found_error = any(msg.get('name') == 'error' for msg in msgs)
         assert found_error, "Player did not get error when joining inactive team before reactivation"
@@ -1021,13 +1022,13 @@ class TestPlayerInteraction:
         second_client.get_received()
         # Player 2 leaves
         second_client.emit('leave_team', {})
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         second_client.get_received()
         
         # Dashboard connects now - test both streaming enabled and disabled scenarios
         dashboard_client = SocketIOTestClient(app, server_socketio)
         dashboard_client.emit('dashboard_join')
-        eventlet.sleep(0.3)
+        time.sleep(0.3)
         initial_msgs = dashboard_client.get_received()
         
         # First check: Dashboard should receive basic metrics regardless of teams streaming state
@@ -1047,12 +1048,12 @@ class TestPlayerInteraction:
         
         # Second check: Enable teams streaming and verify we can see teams data
         dashboard_client.emit('set_teams_streaming', {'enabled': True})
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         dashboard_client.get_received()
         
         # Request teams update after enabling streaming
         dashboard_client.emit('request_teams_update')
-        eventlet.sleep(0.3)
+        time.sleep(0.3)
         dash_msgs = dashboard_client.get_received()
         
         found_team_with_streaming = False
@@ -1073,12 +1074,12 @@ class TestPlayerInteraction:
         """Third player tries to join a full team, gets error, dashboard unchanged."""
         dashboard_client = SocketIOTestClient(app, server_socketio)
         dashboard_client.emit('dashboard_join')
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         dashboard_client.get_received()
         
         # Enable teams streaming
         dashboard_client.emit('set_teams_streaming', {'enabled': True})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         dashboard_client.get_received()
         self.verify_connection(socket_client)
         socket_client.emit('create_team', {'team_name': 'FullTeam'})
@@ -1092,7 +1093,7 @@ class TestPlayerInteraction:
         third_client = SocketIOTestClient(app, server_socketio)
         self.verify_connection(third_client)
         third_client.emit('join_team', {'team_name': 'FullTeam'})
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         msgs = third_client.get_received()
         found_error = any(msg.get('name') == 'error' for msg in msgs)
         assert found_error, "Third player did not get error when joining full team"
@@ -1115,12 +1116,12 @@ class TestPlayerInteraction:
         """Player leaves and immediately rejoins, team goes from waiting_pair to active, dashboard reflects this."""
         dashboard_client = SocketIOTestClient(app, server_socketio)
         dashboard_client.emit('dashboard_join')
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         dashboard_client.get_received()
         
         # Enable teams streaming
         dashboard_client.emit('set_teams_streaming', {'enabled': True})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         dashboard_client.get_received()
         self.verify_connection(socket_client)
         socket_client.emit('create_team', {'team_name': 'QuickRejoinTeam'})
@@ -1132,7 +1133,7 @@ class TestPlayerInteraction:
         second_client.get_received()
         # Player 2 leaves and immediately rejoins
         second_client.emit('leave_team', {})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         second_client.emit('join_team', {'team_name': 'QuickRejoinTeam'})
         self.wait_for_event(second_client, 'team_joined')
         second_client.get_received()
@@ -1160,7 +1161,7 @@ class TestPlayerInteraction:
         new_client = SocketIOTestClient(app, server_socketio)
         self.verify_connection(new_client)
         new_client.emit('reactivate_team', {'team_name': 'CollisionTeam'})
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         msgs = new_client.get_received()
         found_error = any(msg.get('name') == 'error' for msg in msgs)
         assert found_error, "Player did not get error when reactivating already active team name"
@@ -1184,10 +1185,10 @@ class TestPlayerInteraction:
         
         # Both players leave to make team inactive
         socket_client.emit('leave_team', {})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         socket_client.get_received()
         second_client.emit('leave_team', {})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         second_client.get_received()
         
         # Verify team is now inactive in database
@@ -1252,10 +1253,10 @@ class TestPlayerInteraction:
         
         # Both players leave
         socket_client.emit('leave_team', {})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         socket_client.get_received()
         second_client.emit('leave_team', {})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         second_client.get_received()
         
         # New player reactivates by creating team with same name
@@ -1293,7 +1294,7 @@ class TestPlayerInteraction:
         team1_id = team1_created.get('args', [{}])[0].get('team_id')
         socket_client.get_received()
         socket_client.emit('leave_team', {})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         socket_client.get_received()
         
         # Create and deactivate second team
@@ -1302,7 +1303,7 @@ class TestPlayerInteraction:
         team2_id = team2_created.get('args', [{}])[0].get('team_id')
         second_client.get_received()
         second_client.emit('leave_team', {})
-        eventlet.sleep(0.1)
+        time.sleep(0.1)
         second_client.get_received()
         
         # Reactivate first team through create_team
@@ -1346,7 +1347,7 @@ class TestPlayerInteraction:
         # Try to create another team with same name while first is active
         self.verify_connection(second_client)
         second_client.emit('create_team', {'team_name': 'ConflictTeam'})
-        eventlet.sleep(0.2)
+        time.sleep(0.2)
         msgs = second_client.get_received()
         
         # Should get error, not reactivation
@@ -1399,13 +1400,13 @@ class TestPlayerInteraction:
         try:
             from src.sockets.dashboard import force_clear_all_caches
             force_clear_all_caches()
-            eventlet.sleep(0.2)  # Allow time for cache clearing to take effect
+            time.sleep(0.2)  # Allow time for cache clearing to take effect
         except ImportError:
             try:
                 # Fallback to clear_team_caches if force_clear_all_caches not available
                 from src.sockets.dashboard import clear_team_caches
                 clear_team_caches()
-                eventlet.sleep(0.2)
+                time.sleep(0.2)
             except ImportError:
                 pass  # Function may not be available in test environment
 
@@ -1416,19 +1417,19 @@ class TestPlayerInteraction:
             from src.sockets.dashboard import force_clear_all_caches
             # Use force_clear_all_caches to completely clear throttling caches
             force_clear_all_caches()
-            eventlet.sleep(0.2)  # Allow time for cache clearing
+            time.sleep(0.2)  # Allow time for cache clearing
         except ImportError:
             try:
                 # Fallback to clear_team_caches if force_clear_all_caches not available
                 from src.sockets.dashboard import clear_team_caches
                 clear_team_caches()
-                eventlet.sleep(0.2)
+                time.sleep(0.2)
             except ImportError:
                 pass  # Function may not be available in test environment
         
         # Trigger dashboard update after clearing caches
         dashboard_client.emit('dashboard_join')
-        eventlet.sleep(0.5)  # Increased wait time for new throttling delays
+        time.sleep(0.5)  # Increased wait time for new throttling delays
 
     def check_dashboard_team_status(self, dashboard_client, team_name, expected_status, timeout=3.0):
         """Check dashboard for team status, forcing fresh updates if needed and retrying."""
@@ -1441,7 +1442,7 @@ class TestPlayerInteraction:
             else:
                 # First attempt - just trigger normal update
                 dashboard_client.emit('dashboard_join')
-                eventlet.sleep(0.5)  # Increased wait for new throttling delays
+                time.sleep(0.5)  # Increased wait for new throttling delays
             
             dash_msgs = dashboard_client.get_received()
             for msg in dash_msgs:
@@ -1452,7 +1453,7 @@ class TestPlayerInteraction:
                             return True
             
             if attempt < attempts - 1:
-                eventlet.sleep(0.8)  # Increased wait before retry due to throttling
+                time.sleep(0.8)  # Increased wait before retry due to throttling
         
         return False
 

--- a/tests/integration/test_player_interaction.py
+++ b/tests/integration/test_player_interaction.py
@@ -233,7 +233,7 @@ class TestPlayerInteraction:
         
         # Create team
         socket_client.emit('create_team', {'team_name': 'TestTeam'})
-        time.sleep(0.2)  # Use eventlet sleep instead of time.sleep
+        time.sleep(0.2)  # Allow SocketIO test client handlers to process.
 
         # Get all messages since team creation
         messages = socket_client.get_received()
@@ -257,7 +257,7 @@ class TestPlayerInteraction:
         # Setup and create team with first client
         self.verify_connection(socket_client)
         socket_client.emit('create_team', {'team_name': 'TeamToJoin'})
-        time.sleep(0.2)  # Use eventlet sleep
+        time.sleep(0.2)  # Allow SocketIO test client handlers to process.
         socket_client.get_received()  # Clear messages
 
         # Connect second client and join team
@@ -265,7 +265,7 @@ class TestPlayerInteraction:
         second_client.get_received()  # Clear connection messages
         
         second_client.emit('join_team', {'team_name': 'TeamToJoin'})
-        time.sleep(0.2)  # Use eventlet sleep
+        time.sleep(0.2)  # Allow SocketIO test client handlers to process.
 
         # Get all messages since team join
         p2_messages = second_client.get_received()
@@ -328,7 +328,7 @@ class TestPlayerInteraction:
             'item': 'X',  # Use valid ItemEnum value
             'answer': True
         })
-        time.sleep(0.2)  # Use eventlet sleep
+        time.sleep(0.2)  # Allow SocketIO test client handlers to process.
         
         # Get all messages since answer submission
         messages = socket_client.get_received()
@@ -1456,5 +1456,4 @@ class TestPlayerInteraction:
                 time.sleep(0.8)  # Increased wait before retry due to throttling
         
         return False
-
 

--- a/tests/unit/test_dynamic_statistics.py
+++ b/tests/unit/test_dynamic_statistics.py
@@ -3,7 +3,12 @@ Test dynamic statistics functionality for dashboard mode switching.
 """
 import pytest
 from unittest.mock import patch, MagicMock
-from src.sockets.dashboard import _process_single_team, _calculate_team_statistics, _calculate_success_statistics
+from src.sockets.dashboard import (
+    _process_single_team,
+    _process_single_team_optimized,
+    _calculate_team_statistics,
+    _calculate_success_statistics,
+)
 from src.models.quiz_models import ItemEnum
 from src.game_logic import QUESTION_ITEMS, TARGET_COMBO_REPEATS
 
@@ -116,9 +121,10 @@ class TestDynamicStatistics:
             assert result['classic_stats']['trace_average_statistic'] == 0.6
             assert result['new_stats']['trace_average_statistic'] == 0.75
 
-    def test_new_mode_team_processing(self, mock_state, mock_compute_functions):
-        """Test that new mode returns appropriate data structure."""
-        mock_state.game_mode = 'new'
+    @pytest.mark.parametrize('mode', ['simplified', 'aqmjoe', 'new'])
+    def test_success_rate_mode_team_processing(self, mock_state, mock_compute_functions, mode):
+        """Test that success-rate modes return success stats for the main dashboard display."""
+        mock_state.game_mode = mode
         
         with patch('src.sockets.dashboard._calculate_team_statistics') as mock_calc_classic, \
              patch('src.sockets.dashboard._calculate_success_statistics') as mock_calc_success:
@@ -141,10 +147,10 @@ class TestDynamicStatistics:
                 'same_item_balance_uncertainty': 0.06
             }
             
-            result = _process_single_team(1, 'TestTeam', True, '2023-01-01', 5, 'p1', 'p2')
+            result = _process_single_team(1, f'TestTeam-{mode}', True, '2023-01-01', 5, 'p1', 'p2')
             
             assert result is not None
-            assert result['game_mode'] == 'new'
+            assert result['game_mode'] == mode
             
             # Should have both classic and new stats
             assert 'classic_stats' in result
@@ -152,12 +158,113 @@ class TestDynamicStatistics:
             assert 'classic_matrix' in result
             assert 'new_matrix' in result
             
-            # Display should use new stats (correlation_stats points to new)
+            # Display should use success-rate stats
             assert result['correlation_stats'] == mock_calc_success.return_value
             
             # Verify both stats are included
             assert result['classic_stats']['trace_average_statistic'] == 0.6
             assert result['new_stats']['trace_average_statistic'] == 0.75
+            assert result['correlation_matrix'] == mock_compute_functions[2].return_value[0]
+
+    @pytest.mark.parametrize('mode', ['classic', 'simplified', 'aqmjoe', 'new'])
+    def test_optimized_team_processing_uses_mode_appropriate_display_stats(self, mock_state, mode):
+        """Test that optimized team processing uses classic stats only for classic mode."""
+        mock_state.game_mode = mode
+        mock_state.active_teams = {
+            'OptimizedTeam': {
+                'players': ['p1', 'p2'],
+                'combo_tracker': {},
+                'status': 'active',
+            }
+        }
+
+        classic_matrix = [[('classic', 1)]]
+        success_matrix = [[('success', 1)]]
+        classic_stats = {'trace_average_statistic': 0.6}
+        success_stats = {'trace_average_statistic': 0.75}
+
+        with patch('src.sockets.dashboard._compute_team_hashes_optimized', return_value=('hash1', 'hash2')), \
+             patch('src.sockets.dashboard._compute_correlation_matrix_optimized') as mock_corr, \
+             patch('src.sockets.dashboard._compute_success_metrics_optimized') as mock_success, \
+             patch('src.sockets.dashboard._calculate_team_statistics_from_data', return_value=classic_stats), \
+             patch('src.sockets.dashboard._calculate_success_statistics_from_data', return_value=success_stats):
+
+            mock_corr.return_value = (
+                classic_matrix,
+                ['A', 'B', 'X', 'Y'],
+                0.8,
+                {},
+                {},
+                {},
+                {},
+            )
+            mock_success.return_value = (
+                success_matrix,
+                ['A', 'B', 'X', 'Y'],
+                0.75,
+                0.5,
+                {},
+                {},
+                {},
+            )
+
+            result = _process_single_team_optimized(
+                1,
+                'OptimizedTeam',
+                True,
+                '2023-01-01',
+                5,
+                'p1',
+                'p2',
+                [],
+                [],
+                MagicMock(player1_session_id='p1', player2_session_id='p2'),
+            )
+
+        assert result is not None
+        if mode == 'classic':
+            assert result['correlation_stats'] == classic_stats
+            assert result['correlation_matrix'] == classic_matrix
+        else:
+            assert result['correlation_stats'] == success_stats
+            assert result['correlation_matrix'] == success_matrix
+
+    def test_min_stats_sig_combo_coverage_by_mode(self, mock_state, mock_compute_functions):
+        """Test Stats Sig coverage: simplified uses four ordered pairs; AQM Joe uses all sixteen."""
+        simplified_repeats = TARGET_COMBO_REPEATS * 2
+        aqmjoe_repeats = TARGET_COMBO_REPEATS
+        simplified_combos = [('A', 'X'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')]
+        all_ordered_combos = [(i1.value, i2.value) for i1 in QUESTION_ITEMS for i2 in QUESTION_ITEMS]
+
+        mock_state.active_teams = {
+            'CoverageTeam': {
+                'players': ['p1', 'p2'],
+                'combo_tracker': {combo: simplified_repeats for combo in simplified_combos},
+                'status': 'active',
+            }
+        }
+
+        with patch('src.sockets.dashboard._calculate_team_statistics', return_value={}), \
+             patch('src.sockets.dashboard._calculate_success_statistics', return_value={}):
+            mock_state.game_mode = 'simplified'
+            simplified_result = _process_single_team(1, 'CoverageTeam', True, '2023-01-01', 5, 'p1', 'p2')
+
+            _process_single_team.cache_clear()
+            mock_state.game_mode = 'aqmjoe'
+            aqmjoe_result_before = _process_single_team(1, 'CoverageTeam', True, '2023-01-01', 5, 'p1', 'p2')
+
+            mock_state.active_teams['CoverageTeam']['combo_tracker'] = {
+                combo: aqmjoe_repeats for combo in all_ordered_combos
+            }
+            _process_single_team.cache_clear()
+            aqmjoe_result_after = _process_single_team(1, 'CoverageTeam', True, '2023-01-01', 5, 'p1', 'p2')
+
+        assert simplified_result is not None
+        assert aqmjoe_result_before is not None
+        assert aqmjoe_result_after is not None
+        assert simplified_result['min_stats_sig'] is True
+        assert aqmjoe_result_before['min_stats_sig'] is False
+        assert aqmjoe_result_after['min_stats_sig'] is True
 
     def test_success_statistics_calculation(self):
         """Test that success statistics are calculated correctly."""
@@ -188,7 +295,7 @@ class TestDynamicStatistics:
         assert result['chsh_value_statistic'] == 0.5     # normalized_cumulative_score
 
     def test_both_computations_called(self, mock_state, mock_compute_functions):
-        """Test that both classic and new computations are called regardless of mode."""
+        """Test that both classic and success-rate computations are called regardless of mode."""
         mock_state.game_mode = 'classic'
         
         with patch('src.sockets.dashboard._calculate_team_statistics') as mock_calc_classic, \
@@ -220,7 +327,7 @@ class TestDynamicStatistics:
             mock_state.game_mode = 'classic'
             result_classic = _process_single_team(1, 'TestTeam', True, '2023-01-01', 5, 'p1', 'p2')
             
-            # Test new mode
+            # Test a success-rate mode
             mock_state.game_mode = 'new'
             result_new = _process_single_team(1, 'TestTeam', True, '2023-01-01', 5, 'p1', 'p2')
             
@@ -236,9 +343,9 @@ class TestDynamicStatistics:
                 assert 'correlation_stats' in result  # Current display stats
                 assert 'correlation_matrix' in result  # Current display matrix
 
-    def test_new_mode_individual_balance_calculation(self):
-        """Test that NEW mode correctly calculates individual player balance instead of same-question balance."""
-        # Mock success data with realistic player responses for NEW mode
+    def test_success_rate_mode_individual_balance_calculation(self):
+        """Test that success-rate modes calculate individual player balance instead of same-question balance."""
+        # Mock success data with realistic player responses for success-rate modes
         # Player 1 gets A,B questions; Player 2 gets X,Y questions
         success_data = (
             [[(8, 10), (7, 10), (6, 10), (5, 10)] for _ in range(4)],  # success_matrix_tuples
@@ -280,7 +387,7 @@ class TestDynamicStatistics:
         assert result['same_item_balance_uncertainty'] is not None
 
     def test_compute_success_metrics_tracks_individual_responses(self):
-        """Test that compute_success_metrics properly tracks individual player responses for NEW mode."""
+        """Test that compute_success_metrics properly tracks individual player responses for success-rate modes."""
         from unittest.mock import MagicMock
         from src.sockets.dashboard import compute_success_metrics
         from src.models.quiz_models import PairQuestionRounds, Answers, ItemEnum
@@ -298,7 +405,7 @@ class TestDynamicStatistics:
             mock_teams_query.filter_by.return_value.first.return_value = mock_team
             mock_teams_model.query = mock_teams_query
             
-            # Mock rounds data - NEW mode pattern (Player 1: A,B; Player 2: X,Y)
+            # Mock rounds data - simplified mode pattern (Player 1: A,B; Player 2: X,Y)
             mock_round_1 = MagicMock()
             mock_round_1.round_id = 1
             mock_round_1.player1_item = MagicMock()
@@ -377,9 +484,9 @@ class TestDynamicStatistics:
             assert player_responses['Y']['true'] == 1
             assert player_responses['Y']['false'] == 0
 
-    def test_new_mode_dashboard_display_logic(self):
-        """Test that NEW mode dashboard shows only success rate and awards only 🏆 based on success rate."""
-        # Mock teams data for NEW mode
+    def test_success_rate_mode_dashboard_display_logic(self):
+        """Test that success-rate modes show only success rate and award only 🏆 based on success rate."""
+        # Mock teams data for a success-rate mode
         teams_data = [
             {
                 'team_id': 1,
@@ -416,14 +523,14 @@ class TestDynamicStatistics:
             }
         ]
         
-        # Simulate award calculation logic from dashboard.js for NEW mode
-        highestBalancedTrTeamId = None  # Should be None in NEW mode (no 🎯 award)
+        # Simulate award calculation logic from dashboard.js for success-rate modes
+        highestBalancedTrTeamId = None  # Should be None in success-rate modes (no 🎯 award)
         highestChshTeamId = None
         maxChshValue = -float('inf')
         
         eligible_teams = [team for team in teams_data if team['min_stats_sig']]
         
-        # NEW mode award logic: only 🏆 based on success rate
+        # Success-rate mode award logic: only 🏆 based on success rate
         for team in eligible_teams:
             stats = team['new_stats']
             success_rate = stats['trace_average_statistic']
@@ -431,16 +538,16 @@ class TestDynamicStatistics:
                 maxChshValue = success_rate
                 highestChshTeamId = team['team_id']
         
-        # Verify award logic for NEW mode
-        assert highestBalancedTrTeamId is None, "NEW mode should not award 🎯"
+        # Verify award logic for success-rate modes
+        assert highestBalancedTrTeamId is None, "Success-rate modes should not award 🎯"
         assert highestChshTeamId == 1, "Team1 should get 🏆 for highest success rate (85%)"
         assert maxChshValue == 0.85, "Max value should be Team1's success rate"
         
         # Verify that Team3 (not eligible) doesn't get award despite higher success rate
         assert highestChshTeamId != 3, "Ineligible teams should not receive awards"
         
-        # Test table header logic for NEW mode
-        current_game_mode = 'new'
+        # Test table header logic for a success-rate mode
+        current_game_mode = 'aqmjoe'
         
         # Simulate header update logic
         header_config = {}
@@ -452,7 +559,7 @@ class TestDynamicStatistics:
                 'header4': 'CHSH Value 🏆',
                 'columns_visible': [True, True, True, True]
             }
-        else:  # new mode
+        else:  # success-rate modes
             header_config = {
                 'header1': 'Success Rate % 🏆',
                 'header2': 'Response Balance',
@@ -461,13 +568,13 @@ class TestDynamicStatistics:
                 'columns_visible': [True, False, False, False]  # Only first column visible
             }
         
-        # Verify NEW mode header configuration
+        # Verify success-rate mode header configuration
         assert header_config['header1'] == 'Success Rate % 🏆'
         assert header_config['columns_visible'] == [True, False, False, False]
         
-        # Verify that only success rate column is visible in NEW mode
+        # Verify that only success rate column is visible in success-rate modes
         visible_columns = sum(header_config['columns_visible'])
-        assert visible_columns == 1, "NEW mode should only show 1 column (Success Rate %)"
+        assert visible_columns == 1, "Success-rate modes should only show 1 column (Success Rate %)"
         
         # Test that awards string formation works correctly
         def get_awards_string(team_id, highest_balanced_tr_id, highest_chsh_id):
@@ -487,14 +594,14 @@ class TestDynamicStatistics:
         assert team2_awards == "", "Team2 should get no awards"
         assert team3_awards == "", "Team3 should get no awards (not eligible)"
         
-        # Verify no 🎯 awards in NEW mode
+        # Verify no 🎯 awards in success-rate modes
         for team_data in teams_data:
             team_awards = get_awards_string(team_data['team_id'], highestBalancedTrTeamId, highestChshTeamId)
-            assert "🎯" not in team_awards, f"Team {team_data['team_id']} should not have 🎯 award in NEW mode"
+            assert "🎯" not in team_awards, f"Team {team_data['team_id']} should not have 🎯 award in success-rate modes"
 
-    def test_dashboard_success_rate_sorting_new_mode(self):
-        """Test that NEW mode dashboard sorting by success rate works correctly."""
-        # Mock teams data for NEW mode with different success rates
+    def test_dashboard_success_rate_sorting_success_rate_mode(self):
+        """Test that success-rate mode dashboard sorting by success rate works correctly."""
+        # Mock teams data for a success-rate mode with different success rates
         teams_data = [
             {
                 'team_id': 1,
@@ -664,7 +771,7 @@ class TestDynamicStatistics:
         assert actual_order == expected_order, f"Expected {expected_order}, got {actual_order}"
 
     def test_dashboard_success_rate_sorting_mode_aware_behavior(self):
-        """Test that sorting behavior changes correctly between NEW and CLASSIC modes."""
+        """Test that sorting behavior changes correctly between success-rate and CLASSIC modes."""
         # Mock teams data with both new and classic stats
         teams_data = [
             {
@@ -693,7 +800,7 @@ class TestDynamicStatistics:
             }
         ]
         
-        # Test NEW mode sorting (by success rate)
+        # Test success-rate mode sorting (by success rate)
         def get_new_mode_sort_value(team):
             if team.get('new_stats') and team['new_stats']:
                 return team['new_stats'].get('trace_average_statistic', -1)
@@ -702,8 +809,8 @@ class TestDynamicStatistics:
         new_mode_sorted = sorted(teams_data, key=get_new_mode_sort_value, reverse=True)
         new_mode_order = [team['team_name'] for team in new_mode_sorted]
         
-        # In NEW mode: Team_Alpha (0.95) should come before Team_Beta (0.65)
-        assert new_mode_order == ['Team_Alpha', 'Team_Beta'], f"NEW mode sort failed: {new_mode_order}"
+        # In success-rate modes: Team_Alpha (0.95) should come before Team_Beta (0.65)
+        assert new_mode_order == ['Team_Alpha', 'Team_Beta'], f"Success-rate mode sort failed: {new_mode_order}"
         
         # Test CLASSIC mode sorting (by CHSH value)
         def get_classic_mode_sort_value(team):
@@ -735,4 +842,4 @@ class TestDynamicStatistics:
         
         # Test case insensitivity and edge cases
         assert get_dropdown_text('NEW') == 'Sort by Success Rate'  # Different case
-        assert get_dropdown_text('unknown') == 'Sort by Success Rate'  # Default to new mode
+        assert get_dropdown_text('unknown') == 'Sort by Success Rate'  # Default to success-rate behaviour

--- a/tests/unit/test_game_sockets.py
+++ b/tests/unit/test_game_sockets.py
@@ -1,7 +1,4 @@
 import pytest
-import eventlet
-eventlet.monkey_patch()
-
 from unittest.mock import MagicMock, patch, ANY
 from datetime import datetime
 from flask import request

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -23,6 +23,8 @@ def test_app_state_initialization():
     
     assert isinstance(state.team_id_to_name, dict)
     assert len(state.team_id_to_name) == 0
+    assert state.game_mode == 'aqmjoe'
+    assert state.game_theme == 'aqmjoe'
 
 def test_app_state_reset():
     """Test that AppState.reset() properly clears all state"""
@@ -50,6 +52,8 @@ def test_app_state_reset():
     assert len(state.connected_players) == 0
     assert state.game_paused is False
     assert len(state.team_id_to_name) == 0
+    assert state.game_mode == 'aqmjoe'
+    assert state.game_theme == 'aqmjoe'
 
 def test_app_state_team_tracking():
     """Test adding and removing teams from state"""

--- a/tests/unit/test_team_management.py
+++ b/tests/unit/test_team_management.py
@@ -1235,12 +1235,122 @@ def test_track_disconnected_player_no_slot():
     
     # Mock team_info that will cause _get_player_slot_in_team to return None
     team_info = {'players': ['other_player']}  # test_sid not in players
-    
+
     with patch('src.sockets.team_management.state') as mock_state:
         mock_state.disconnected_players = {}
-        
+
         # Should not add to disconnected_players when slot is None
         _track_disconnected_player('test_team', 'test_sid', team_info)
-        
+
         # No disconnected player should be tracked
         assert 'test_team' not in mock_state.disconnected_players
+
+
+# ---------------------------------------------------------------------------
+# _validate_team_name
+# ---------------------------------------------------------------------------
+
+class TestValidateTeamName:
+    def setup_method(self):
+        from src.sockets.team_management import _validate_team_name
+        self.validate = _validate_team_name
+
+    def test_valid_simple(self):
+        ok, msg, name = self.validate('Alpha')
+        assert ok and name == 'Alpha'
+
+    def test_valid_with_allowed_specials(self):
+        ok, msg, name = self.validate('Team-A_(1)')
+        assert ok and name == 'Team-A_(1)'
+
+    def test_trims_whitespace(self):
+        ok, msg, name = self.validate('  Padded  ')
+        assert ok and name == 'Padded'
+
+    def test_empty_string(self):
+        ok, msg, name = self.validate('')
+        assert not ok
+        assert 'required' in msg
+
+    def test_whitespace_only(self):
+        ok, msg, name = self.validate('   ')
+        assert not ok
+        assert 'required' in msg
+
+    def test_non_string_dict(self):
+        ok, msg, name = self.validate({'x': 1})
+        assert not ok
+        assert 'required' in msg
+
+    def test_non_string_none(self):
+        ok, msg, name = self.validate(None)
+        assert not ok
+        assert 'required' in msg
+
+    def test_non_string_int(self):
+        ok, msg, name = self.validate(42)
+        assert not ok
+        assert 'required' in msg
+
+    def test_disallows_special_chars(self):
+        for bad in ['Team<1>', 'Name"here', "It's", 'slash/name', 'back\\slash']:
+            ok, msg, _ = self.validate(bad)
+            assert not ok, f"Expected rejection for: {bad}"
+            assert 'only contain' in msg
+
+    def test_max_length_exactly_50(self):
+        ok, msg, name = self.validate('A' * 50)
+        assert ok and len(name) == 50
+
+    def test_max_length_exceeded(self):
+        ok, msg, name = self.validate('A' * 51)
+        assert not ok
+        assert '50' in msg
+
+    def test_create_team_rejects_invalid_name(self, mock_request_context):
+        with patch('src.sockets.team_management.emit') as mock_emit:
+            from src.sockets.team_management import on_create_team
+            on_create_team({'team_name': 'Bad<Name>'})
+            mock_emit.assert_called_once_with(
+                'error',
+                {'message': 'Team name may only contain letters, numbers, spaces, and - _ ( )'}
+            )
+
+    def test_create_team_rejects_non_dict_data(self, mock_request_context):
+        with patch('src.sockets.team_management.emit') as mock_emit:
+            from src.sockets.team_management import on_create_team
+            on_create_team("not-a-dict")
+            mock_emit.assert_called_once_with(
+                'error',
+                {'message': 'Team name is required'}
+            )
+
+    def test_create_team_trims_and_accepts(self, mock_request_context):
+        with patch('src.sockets.team_management.emit') as mock_emit, \
+             patch('src.sockets.team_management.socketio.emit'), \
+             patch('src.sockets.dashboard.emit_dashboard_team_update'), \
+             patch('src.sockets.team_management.join_room'):
+            from src.sockets.team_management import on_create_team
+            on_create_team({'team_name': '  TrimMe  '})
+
+            # team_created should carry the trimmed name
+            mock_emit.assert_any_call(
+                'team_created',
+                {
+                    'team_name': 'TrimMe',
+                    'team_id': ANY,
+                    'message': 'Team created. Waiting for another player.',
+                    'game_started': ANY,
+                    'game_mode': ANY,
+                    'game_theme': ANY,
+                    'player_slot': 1,
+                }
+            )
+
+            # Cleanup
+            from src.config import db
+            from src.models.quiz_models import Teams
+            team = Teams.query.filter_by(team_name='TrimMe').first()
+            if team:
+                db.session.delete(team)
+                db.session.commit()


### PR DESCRIPTION
## Summary
- Fix dashboard team processing so `simplified`, `aqmjoe`, and legacy `new` use success-rate stats for the main display, while `classic` keeps CHSH/correlation stats.
- Preserve AQM Joe Stats Sig semantics by requiring all 16 ordered item-pair combinations before awards.
- Add dashboard/statistics tests, including an AQM Joe perfect-vs-seeded-random rehearsal case.
- Document AQM Joe default behaviour, Stats Sig eligibility, independent team rounds, and dashboard clients in the connected player count.

## Validation
- `venv/bin/pytest tests/unit/test_dynamic_statistics.py tests/integration/test_aqmjoe_integration.py -q`
- Maestri portal rehearsal: PerfectTeam reached `100.0%` with 🏆; RandomTeam reached `65.5% ± 3.9%` with no trophy after Stats Sig.

## Notes
- This PR targets `master` from the existing `dev/v2.5.0.1` branch. That branch already contains earlier v2.5.0.1 changes in addition to the dashboard stats fix.